### PR TITLE
hypershift-kubevirt: switch to Azure, drop ODF dependency

### DIFF
--- a/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-main.yaml
+++ b/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-main.yaml
@@ -389,7 +389,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-release-4.22.yaml
+++ b/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-release-4.22.yaml
@@ -359,7 +359,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-release-4.23.yaml
+++ b/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-release-4.23.yaml
@@ -374,7 +374,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-release-5.0.yaml
+++ b/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-release-5.0.yaml
@@ -375,7 +375,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-release-5.1.yaml
+++ b/ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-release-5.1.yaml
@@ -374,7 +374,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-master.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-master.yaml
@@ -358,11 +358,14 @@ tests:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn-local-to-shared-gateway-mode-migration
 - always_run: false
-  as: e2e-aws-hypershift-ovn-kubevirt
+  as: e2e-azure-hypershift-ovn-kubevirt
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - always_run: false
   as: qe-perfscale-aws-ovn-medium-cluster-density
   optional: true

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.18.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.18.yaml
@@ -330,11 +330,14 @@ tests:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn-local-to-shared-gateway-mode-migration
 - always_run: false
-  as: e2e-aws-hypershift-ovn-kubevirt
+  as: e2e-azure-hypershift-ovn-kubevirt
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - always_run: false
   as: qe-perfscale-aws-ovn-medium-cluster-density
   optional: true

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.19.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.19.yaml
@@ -333,11 +333,14 @@ tests:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn-local-to-shared-gateway-mode-migration
 - always_run: false
-  as: e2e-aws-hypershift-ovn-kubevirt
+  as: e2e-azure-hypershift-ovn-kubevirt
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - always_run: false
   as: qe-perfscale-aws-ovn-medium-cluster-density
   optional: true

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.20.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.20.yaml
@@ -333,11 +333,14 @@ tests:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn-local-to-shared-gateway-mode-migration
 - always_run: false
-  as: e2e-aws-hypershift-ovn-kubevirt
+  as: e2e-azure-hypershift-ovn-kubevirt
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - always_run: false
   as: qe-perfscale-aws-ovn-medium-cluster-density
   optional: true

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21.yaml
@@ -364,12 +364,15 @@ tests:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn-local-to-shared-gateway-mode-migration
 - always_run: false
-  as: e2e-aws-hypershift-ovn-kubevirt
+  as: e2e-azure-hypershift-ovn-kubevirt
   optional: true
   skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - always_run: false
   as: qe-perfscale-aws-ovn-medium-cluster-density
   optional: true

--- a/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.22.yaml
+++ b/ci-operator/config/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.22.yaml
@@ -358,11 +358,14 @@ tests:
       GATEWAY_MODE: local
     workflow: openshift-e2e-aws-ovn-local-to-shared-gateway-mode-migration
 - always_run: false
-  as: e2e-aws-hypershift-ovn-kubevirt
+  as: e2e-azure-hypershift-ovn-kubevirt
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - always_run: false
   as: qe-perfscale-aws-ovn-medium-cluster-density
   optional: true

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml
@@ -394,7 +394,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.15__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.15__periodics.yaml
@@ -74,8 +74,6 @@ tests:
   cron: 35 12 10 4 *
   steps:
     cluster_profile: openshift-org-aws
-    env:
-      ODF_OPERATOR_CHANNEL: stable-4.15
     workflow: hypershift-kubevirt-csi-e2e
 - as: e2e-kubevirt-aws-ovn
   cron: 59 8 15 5 *
@@ -88,7 +86,6 @@ tests:
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      ODF_OPERATOR_CHANNEL: stable-4.15
     workflow: hypershift-kubevirt-e2e-aws
 - as: e2e-kubevirt-azure
   cron: 40 2 8 5 *
@@ -96,7 +93,6 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.15
     workflow: hypershift-kubevirt-azure-conformance
 zz_generated_metadata:
   branch: release-4.15

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.16__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.16__periodics.yaml
@@ -75,8 +75,6 @@ tests:
   cron: 31 0 7 6 *
   steps:
     cluster_profile: openshift-org-aws
-    env:
-      ODF_OPERATOR_CHANNEL: stable-4.16
     workflow: hypershift-kubevirt-csi-e2e
 - as: e2e-kubevirt-aws-ovn
   cron: 25 22 14 5 *
@@ -89,7 +87,6 @@ tests:
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      ODF_OPERATOR_CHANNEL: stable-4.16
     workflow: hypershift-kubevirt-e2e-aws
 - as: e2e-kubevirt-azure
   cron: 42 20 26 9 *
@@ -97,7 +94,6 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.16
     workflow: hypershift-kubevirt-azure-conformance
 zz_generated_metadata:
   branch: release-4.16

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.17__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.17__periodics.yaml
@@ -116,8 +116,6 @@ tests:
   cron: 41 7 7 1 *
   steps:
     cluster_profile: openshift-org-aws
-    env:
-      ODF_OPERATOR_CHANNEL: stable-4.17
     workflow: hypershift-kubevirt-csi-e2e
 - as: e2e-kubevirt-aws-ovn
   cron: 37 9 3 11 *
@@ -129,14 +127,11 @@ tests:
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      ODF_OPERATOR_CHANNEL: stable-4.17
     workflow: hypershift-kubevirt-e2e-aws
 - as: e2e-kubevirt-azure
   cron: 17 5 25 3 *
   steps:
     cluster_profile: openshift-org-azure
-    env:
-      ODF_OPERATOR_CHANNEL: stable-4.17
     workflow: hypershift-kubevirt-azure-conformance
 zz_generated_metadata:
   branch: release-4.17

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.18__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.18__periodics.yaml
@@ -163,8 +163,6 @@ tests:
   cron: 23 17 6 10 *
   steps:
     cluster_profile: openshift-org-aws
-    env:
-      ODF_OPERATOR_CHANNEL: stable-4.18
     workflow: hypershift-kubevirt-csi-e2e
 - as: e2e-kubevirt-aws-ovn
   cron: 47 2 24 7 *
@@ -176,7 +174,6 @@ tests:
       ENABLE_HYPERSHIFT_OPERATOR_DEFAULTING_WEBHOOK: "true"
       ETCD_STORAGE_CLASS: gp3-csi
       KUBEVIRT_CSI_INFRA: gp3-csi
-      ODF_OPERATOR_CHANNEL: stable-4.18
     workflow: hypershift-kubevirt-e2e-aws
 - as: e2e-azure-kubevirt-ovn
   cron: 56 13 28 3 *
@@ -184,7 +181,6 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
-      ODF_OPERATOR_CHANNEL: stable-4.18
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance
@@ -194,7 +190,6 @@ tests:
     cluster_profile: openshift-org-aws
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
-      ODF_OPERATOR_CHANNEL: stable-4.18
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.19__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.19__periodics.yaml
@@ -314,7 +314,6 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
-      ODF_OPERATOR_CHANNEL: stable-4.19
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.20__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.20__periodics.yaml
@@ -332,7 +332,6 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.21__periodics.yaml
@@ -380,7 +380,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22.yaml
@@ -356,7 +356,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.22__periodics.yaml
@@ -257,7 +257,6 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23.yaml
@@ -371,7 +371,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23__periodics.yaml
@@ -281,7 +281,6 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0.yaml
@@ -372,7 +372,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0__periodics.yaml
@@ -280,7 +280,6 @@ tests:
     cluster_profile: openshift-org-azure
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.1.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.1.yaml
@@ -371,7 +371,6 @@ tests:
     env:
       CNV_SUBSCRIPTION_SOURCE: redhat-operators
       HYPERSHIFT_NODE_COUNT: "2"
-      ODF_OPERATOR_CHANNEL: stable-4.20
       TEST_INCLUDES: sig-kubevirt
       TEST_SUITE: openshift/conformance/parallel/minimal
     workflow: hypershift-kubevirt-azure-conformance

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master.yaml
@@ -372,6 +372,15 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial
+- always_run: false
+  as: e2e-azure-ovn-hypershift-kubevirt
+  optional: true
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18.yaml
@@ -318,11 +318,14 @@ tests:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial
 - always_run: false
-  as: e2e-aws-ovn-hypershift-kubevirt
+  as: e2e-azure-ovn-hypershift-kubevirt
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19.yaml
@@ -331,11 +331,14 @@ tests:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial
 - always_run: false
-  as: e2e-aws-ovn-hypershift-kubevirt
+  as: e2e-azure-ovn-hypershift-kubevirt
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20.yaml
@@ -331,11 +331,14 @@ tests:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial
 - always_run: false
-  as: e2e-aws-ovn-hypershift-kubevirt
+  as: e2e-azure-ovn-hypershift-kubevirt
   optional: true
   steps:
-    cluster_profile: openshift-org-aws
-    workflow: hypershift-kubevirt-conformance
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21.yaml
@@ -359,6 +359,15 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial
+- always_run: false
+  as: e2e-azure-ovn-hypershift-kubevirt
+  optional: true
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - as: security
   optional: true
   steps:

--- a/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
+++ b/ci-operator/config/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22.yaml
@@ -370,6 +370,15 @@ tests:
     env:
       EXTRA_MG_ARGS: --host-network
     workflow: openshift-e2e-aws-ovn-serial
+- always_run: false
+  as: e2e-azure-ovn-hypershift-kubevirt
+  optional: true
+  steps:
+    cluster_profile: openshift-org-azure
+    env:
+      TEST_INCLUDES: sig-kubevirt
+      TEST_SUITE: openshift/conformance/parallel/minimal
+    workflow: hypershift-kubevirt-azure-conformance
 - as: security
   optional: true
   steps:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-master-presubmits.yaml
@@ -316,87 +316,6 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build03
-    context: ci/prow/e2e-aws-hypershift-ovn-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-master-e2e-aws-hypershift-ovn-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-hypershift-ovn-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-hypershift-ovn-kubevirt,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^master$
-    - ^master-
-    cluster: build03
     context: ci/prow/e2e-aws-ovn-fdp-qe
     decorate: true
     labels:
@@ -1611,6 +1530,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-windows,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build03
+    context: ci/prow/e2e-azure-hypershift-ovn-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-network-operator-master-e2e-azure-hypershift-ovn-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-hypershift-ovn-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-hypershift-ovn-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-hypershift-ovn-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.18-presubmits.yaml
@@ -388,87 +388,6 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.18-upgrade-from-stable-4.17-images,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.18$
-    - ^release-4\.18-
-    cluster: build11
-    context: ci/prow/e2e-aws-hypershift-ovn-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-release-4.18-e2e-aws-hypershift-ovn-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-hypershift-ovn-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-hypershift-ovn-kubevirt,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.18$
@@ -1273,6 +1192,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-windows,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.18$
+    - ^release-4\.18-
+    cluster: build11
+    context: ci/prow/e2e-azure-hypershift-ovn-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-network-operator-release-4.18-e2e-azure-hypershift-ovn-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-hypershift-ovn-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-hypershift-ovn-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-hypershift-ovn-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.19-presubmits.yaml
@@ -388,87 +388,6 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.19-upgrade-from-stable-4.18-images,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.19$
-    - ^release-4\.19-
-    cluster: build11
-    context: ci/prow/e2e-aws-hypershift-ovn-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-release-4.19-e2e-aws-hypershift-ovn-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-hypershift-ovn-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-hypershift-ovn-kubevirt,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.19$
@@ -1355,6 +1274,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-windows,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build11
+    context: ci/prow/e2e-azure-hypershift-ovn-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-network-operator-release-4.19-e2e-azure-hypershift-ovn-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-hypershift-ovn-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-hypershift-ovn-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-hypershift-ovn-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.20-presubmits.yaml
@@ -305,87 +305,6 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )4.20-upgrade-from-stable-4.19-images,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.20$
-    - ^release-4\.20-
-    cluster: build11
-    context: ci/prow/e2e-aws-hypershift-ovn-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-release-4.20-e2e-aws-hypershift-ovn-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-hypershift-ovn-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-hypershift-ovn-kubevirt,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.20$
@@ -1272,6 +1191,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-windows,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build11
+    context: ci/prow/e2e-azure-hypershift-ovn-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-network-operator-release-4.20-e2e-azure-hypershift-ovn-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-hypershift-ovn-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-hypershift-ovn-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-hypershift-ovn-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.21-presubmits.yaml
@@ -316,88 +316,6 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: build11
-    context: ci/prow/e2e-aws-hypershift-ovn-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-aws-hypershift-ovn-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
-    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-hypershift-ovn-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-hypershift-ovn-kubevirt,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.21$
-    - ^release-4\.21-
-    cluster: build11
     context: ci/prow/e2e-aws-ovn-hypershift-conformance
     decorate: true
     labels:
@@ -1458,6 +1376,88 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-windows,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build11
+    context: ci/prow/e2e-azure-hypershift-ovn-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-network-operator-release-4.21-e2e-azure-hypershift-ovn-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-hypershift-ovn-kubevirt
+    skip_if_only_changed: ^(docs|\.vscode)/|\.md$|^(\.gitignore|\.gitattributes|\.golangci\.yaml|OWNERS|OWNERS_ALIASES|LICENSE|sample-.*\.yaml)$
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-hypershift-ovn-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-hypershift-ovn-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-network-operator/openshift-cluster-network-operator-release-4.22-presubmits.yaml
@@ -6,87 +6,6 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build11
-    context: ci/prow/e2e-aws-hypershift-ovn-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-cluster-network-operator-release-4.22-e2e-aws-hypershift-ovn-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-hypershift-ovn-kubevirt
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-hypershift-ovn-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-hypershift-ovn-kubevirt,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.22$
-    - ^release-4\.22-
-    cluster: build11
     context: ci/prow/e2e-aws-ovn-fdp-qe
     decorate: true
     labels:
@@ -1301,6 +1220,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-windows,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build11
+    context: ci/prow/e2e-azure-hypershift-ovn-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-network-operator-release-4.22-e2e-azure-hypershift-ovn-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-hypershift-ovn-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-hypershift-ovn-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-hypershift-ovn-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-master-presubmits.yaml
@@ -1928,6 +1928,87 @@ presubmits:
     - ^master$
     - ^master-
     cluster: build11
+    context: ci/prow/e2e-azure-ovn-hypershift-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-master-e2e-azure-ovn-hypershift-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-ovn-hypershift-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-ovn-hypershift-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-ovn-hypershift-kubevirt,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^master$
+    - ^master-
+    cluster: build11
     context: ci/prow/e2e-azure-ovn-techpreview
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.18-presubmits.yaml
@@ -784,87 +784,6 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-hypershift-conformance-techpreview,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.18$
-    - ^release-4\.18-
-    cluster: build09
-    context: ci/prow/e2e-aws-ovn-hypershift-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-ovn-kubernetes-release-4.18-e2e-aws-ovn-hypershift-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-ovn-hypershift-kubevirt
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-ovn-hypershift-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-ovn-hypershift-kubevirt,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.18$
@@ -1748,6 +1667,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-azure-ovn,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.18$
+    - ^release-4\.18-
+    cluster: build09
+    context: ci/prow/e2e-azure-ovn-hypershift-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-release-4.18-e2e-azure-ovn-hypershift-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-ovn-hypershift-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-ovn-hypershift-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-ovn-hypershift-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.19-presubmits.yaml
@@ -867,87 +867,6 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-hypershift-conformance-techpreview,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.19$
-    - ^release-4\.19-
-    cluster: build09
-    context: ci/prow/e2e-aws-ovn-hypershift-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-ovn-kubernetes-release-4.19-e2e-aws-ovn-hypershift-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-ovn-hypershift-kubevirt
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-ovn-hypershift-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-ovn-hypershift-kubevirt,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.19$
@@ -1993,6 +1912,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-azure-ovn,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.19$
+    - ^release-4\.19-
+    cluster: build09
+    context: ci/prow/e2e-azure-ovn-hypershift-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-release-4.19-e2e-azure-ovn-hypershift-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-ovn-hypershift-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-ovn-hypershift-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-ovn-hypershift-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.20-presubmits.yaml
@@ -867,87 +867,6 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-aws-ovn-hypershift-conformance-techpreview,?($|\s.*)
   - agent: kubernetes
-    always_run: false
-    branches:
-    - ^release-4\.20$
-    - ^release-4\.20-
-    cluster: build09
-    context: ci/prow/e2e-aws-ovn-hypershift-kubevirt
-    decorate: true
-    labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-ovn-kubernetes-release-4.20-e2e-aws-ovn-hypershift-kubevirt
-    optional: true
-    rerun_command: /test e2e-aws-ovn-hypershift-kubevirt
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-aws-ovn-hypershift-kubevirt
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )e2e-aws-ovn-hypershift-kubevirt,?($|\s.*)
-  - agent: kubernetes
     always_run: true
     branches:
     - ^release-4\.20$
@@ -1912,6 +1831,87 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e-azure-ovn,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.20$
+    - ^release-4\.20-
+    cluster: build09
+    context: ci/prow/e2e-azure-ovn-hypershift-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-release-4.20-e2e-azure-ovn-hypershift-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-ovn-hypershift-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-ovn-hypershift-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-ovn-hypershift-kubevirt,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.21-presubmits.yaml
@@ -1775,6 +1775,87 @@ presubmits:
     - ^release-4\.21$
     - ^release-4\.21-
     cluster: build09
+    context: ci/prow/e2e-azure-ovn-hypershift-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-release-4.21-e2e-azure-ovn-hypershift-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-ovn-hypershift-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-ovn-hypershift-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-ovn-hypershift-kubevirt,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.21$
+    - ^release-4\.21-
+    cluster: build09
     context: ci/prow/e2e-azure-ovn-techpreview
     decorate: true
     labels:

--- a/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ovn-kubernetes/openshift-ovn-kubernetes-release-4.22-presubmits.yaml
@@ -1626,6 +1626,87 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build09
+    context: ci/prow/e2e-azure-ovn-hypershift-kubevirt
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: azure4
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ovn-kubernetes-release-4.22-e2e-azure-ovn-hypershift-kubevirt
+    optional: true
+    rerun_command: /test e2e-azure-ovn-hypershift-kubevirt
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-azure-ovn-hypershift-kubevirt
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-azure-ovn-hypershift-kubevirt,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build09
     context: ci/prow/e2e-azure-ovn-techpreview
     decorate: true
     labels:

--- a/ci-operator/step-registry/hypershift/kubevirt/azure/conformance/hypershift-kubevirt-azure-conformance-workflow.yaml
+++ b/ci-operator/step-registry/hypershift/kubevirt/azure/conformance/hypershift-kubevirt-azure-conformance-workflow.yaml
@@ -25,7 +25,6 @@ workflow:
       CONTROL_PLANE_INSTANCE_TYPE: Standard_D16s_v3
       ETCD_STORAGE_CLASS: managed-csi
       KUBEVIRT_CSI_INFRA: managed-csi
-      ODF_BACKEND_STORAGE_CLASS: managed-csi
       SKIP_MONITOR_TEST: "true"
     leases:
       - env: LEASED_RESOURCE
@@ -33,7 +32,6 @@ workflow:
     pre:
     - chain: ipi-azure-pre
     - ref: hypershift-kubevirt-install
-    - ref: hypershift-kubevirt-install-odf
     - ref: hypershift-install
     - ref: hypershift-kubevirt-create
     - ref: hypershift-kubevirt-health-check


### PR DESCRIPTION
## Summary

- Switch hypershift-kubevirt conformance presubmit from AWS to Azure for ovn-kubernetes and cluster-network-operator
- Remove ODF install step from `hypershift-kubevirt-azure-conformance` workflow
- Remove orphaned `ODF_OPERATOR_CHANNEL` overrides from all `openshift/hypershift` configs
- VMs use `managed-csi` (RWO) instead of ODF Ceph RBD (RWX)
- Live migration works via KubeVirt volume migration (GA since v1.4 / OpenShift Virt 4.18+)

## Changes

### AWS to Azure switch (from PR #79039)
- Switch workflow from `hypershift-kubevirt-conformance` to `hypershift-kubevirt-azure-conformance`
- Update `cluster_profile` to `openshift-org-azure`, rename tests from `e2e-aws-*` to `e2e-azure-*`
- Scope conformance tests: `TEST_SUITE=openshift/conformance/parallel/minimal` with `TEST_INCLUDES=sig-kubevirt`
- Add presubmit to ovn-kubernetes 4.21 and 4.22 (previously only existed on 4.18-4.20)

### Drop ODF dependency
- Remove `hypershift-kubevirt-install-odf` ref from the workflow pre chain
- Remove `ODF_BACKEND_STORAGE_CLASS` env var from the workflow
- Remove orphaned `ODF_OPERATOR_CHANNEL` overrides from 20 hypershift configs (4.15-5.1)

## Why drop ODF

No ODF version supports OCP 5.0. Every ODF release sets `olm.maxOpenShiftVersion` to N+1
of its own minor (e.g., ODF 4.21 → max 4.22, ODF 4.22 → max 4.23). On OCP 5.0 the ODF
operator deployment never becomes ready, Ceph/RBD CSI never registers, DataVolumes stay
Pending, and VMs never boot.

Verified failures on recent runs:
- `kubevirt-csi-driver` (May 8, 2026): same ODF install failure
- `cluster-api-provider-kubevirt` (May 6, 2026): same ODF install failure

## How live migration works without ODF

KubeVirt volume migration (GA since KubeVirt v1.4 / OpenShift Virt 4.18+) allows live
migrating VMs with RWO volumes. When a `VirtualMachineInstanceMigration` is created,
KubeVirt detects RWO volumes and automatically migrates storage alongside the VM using
QEMU block mirroring. No RWX/shared storage needed.

The `sig-kubevirt` migration test in `openshift/origin` (`test/extended/kubevirt/migration.go`)
creates `VirtualMachineInstanceMigration` CRs and waits for completion — it works
transparently with either RWX or RWO+volume-migration.

## Benefits

- Fixes OCP 5.0 (and future versions) without waiting for ODF compatibility
- Saves ~10 minutes per job run (ODF install time)
- Saves ~300Gi Azure disk per job (no 3x100Gi Ceph OSD disks)
- Eliminates flaky ODF auto-detect/fallback catalog logic
- Works across all branches (4.15-5.1) since all use CNV >= 4.18

## Affected repos and branches

| Repo | Branches |
|------|----------|
| `ovn-kubernetes` | master, 4.18, 4.19, 4.20, 4.21 (new), 4.22 (new) |
| `cluster-network-operator` | master, 4.18, 4.19, 4.20, 4.21, 4.22 |
| `openshift/hypershift` | main, 4.15-5.1 (cleanup only) |
| `openshift-priv/hypershift` | main, 4.22-5.1 (cleanup only) |

All tests are `always_run: false` and `optional: true` (triggered via `/test`).

Supersedes #79039

/cc @jcaamano @kyrtapz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes the Open Data Foundation (ODF) dependency from the HyperShift KubeVirt Azure conformance testing pipeline in the openshift/release repository so KubeVirt conformance jobs run without installing ODF.

## What this changes (practical impact)

- Affects CI configuration and step-registry in openshift/release: the hypershift kubevirt Azure conformance workflow and ~20 hypershift-related job configs across ci-operator config files in both openshift/ and openshift-priv/.
- The hypershift-kubevirt-azure-conformance workflow no longer runs the hypershift-kubevirt-install-odf pre-step and no longer relies on ODF-specific env vars (ODF_BACKEND_STORAGE_CLASS removed from workflow env).
- Removed ODF operator channel overrides (ODF_OPERATOR_CHANNEL) from multiple CI job definitions and periodic job configs across releases (4.14–5.1 / main).
- Jobs now use Azure managed CSI (managed-csi / Azure Managed Disks, RWO) rather than ODF Ceph RBD (RWX) and set CNV_SUBSCRIPTION_SOURCE: redhat-operators where appropriate.
- Tests/workflows are adjusted to run on at least 2 nodes (HYPERSHIFT_NODE_COUNT: "2") and to explicitly select the KubeVirt sig conformance subset (TEST_INCLUDES: sig-kubevirt, TEST_SUITE: openshift/conformance/parallel/minimal) so the sig-kubevirt migration test exercises KubeVirt volume migration.
- Several CI job entries targeting AWS were retargeted/added for Azure where relevant (new optional Azure e2e jobs added in cluster-network-operator and ovn-kubernetes configs).

## Reason

ODF releases declare an olm.maxOpenShiftVersion that prevents ODF operator readiness on OCP 5.0; with ODF unavailable Ceph/RBD CSI never registers, DataVolumes stay Pending and VMs fail to boot. Switching to Azure managed disks and relying on KubeVirt volume migration restores testability on OCP 5.0.

## Benefits / impact

- Restores KubeVirt conformance CI compatibility with OCP 5.0 immediately (no waiting on an ODF release that supports OCP 5.0).
- Saves time and resources: removes the ODF install step (~10 minutes per job) and reduces Azure disk usage (~300 Gi per run).
- Increases stability by removing flaky ODF auto-detect/fallback logic.
- Uses KubeVirt GA volume migration (available since KubeVirt v1.4/OpenShift Virt 4.18+) to migrate RWO volumes for live-migration tests; conformance test creation of VirtualMachineInstanceMigration CRs still validates live migration behavior.

## Files / areas changed (high level)

- Step-registry: removed reference to hypershift-kubevirt-install-odf from hypershift-kubevirt-azure-conformance workflow file and removed ODF_BACKEND_STORAGE_CLASS from that workflow's env.
- ci-operator configs (approx. 20 hypershift-related files in ci-operator/config/openshift and ci-operator/config/openshift-priv): removed ODF_OPERATOR_CHANNEL entries and added/adjusted CNV_SUBSCRIPTION_SOURCE, HYPERSHIFT_NODE_COUNT, and TEST_* env entries where applicable.
- CI job lists in cluster-network-operator and ovn-kubernetes configs: added optional Azure hypershift-kubevirt conformance jobs (replacing or supplementing previous AWS entries).

## Notes

- ODF-related step/utility files and other ODF step-registry entries remain elsewhere in the repo (this PR removes the ODF install usage from the hypershift-kubevirt Azure conformance path specifically).
- The change is targeted at restoring reliability across branches that run CNV ≥ 4.18 and spans branch configs from 4.15 → 5.1 and main.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->