### PR TITLE
Create Prow jobs for standalone-distributed-tracing-3.10 release branch

### DIFF
--- a/ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-3.10.yaml
+++ b/ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-3.10.yaml
@@ -1,0 +1,38 @@
+build_root:
+  image_stream_tag:
+    name: openshift-docs-asciidoc
+    namespace: ocp
+    tag: latest
+  use_build_cache: true
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 400m
+      memory: 800Mi
+tests:
+- as: validate-asciidoc
+  steps:
+    env:
+      DISTROS: openshift-distributed-tracing
+      PREVIEW_SITE: ocpdocs-pr
+    test:
+    - ref: openshift-docs-build-docs
+    - ref: openshift-docs-preview-comment-pages
+    - ref: openshift-docs-asciidoctor
+    - ref: openshift-docs-lint-topicmaps
+    - ref: openshift-docs-jira-links
+    - ref: openshift-docs-vale-review
+- as: validate-portal
+  steps:
+    env:
+      BUILD: build_for_portal.py
+      DISTROS: openshift-distributed-tracing
+      VERSION: "3.10"
+    test:
+    - ref: openshift-docs-portal
+zz_generated_metadata:
+  branch: standalone-distributed-tracing-3.10
+  org: openshift
+  repo: openshift-docs

--- a/ci-operator/jobs/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-3.10-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-3.10-presubmits.yaml
@@ -1,0 +1,148 @@
+presubmits:
+  openshift/openshift-docs:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^standalone-distributed-tracing-3\.10$
+    - ^standalone-distributed-tracing-3\.10-
+    cluster: build01
+    context: ci/prow/validate-asciidoc
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-docs-standalone-distributed-tracing-3.10-validate-asciidoc
+    rerun_command: /test validate-asciidoc
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-asciidoc
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-asciidoc,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^standalone-distributed-tracing-3\.10$
+    - ^standalone-distributed-tracing-3\.10-
+    cluster: build01
+    context: ci/prow/validate-portal
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-docs-standalone-distributed-tracing-3.10-validate-portal
+    rerun_command: /test validate-portal
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-portal
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-portal,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds CI configuration and generated Prow presubmit jobs to enable automated documentation validation for the standalone-distributed-tracing-3.10 release branch of the openshift/openshift-docs repository.

What changed
- Adds a new ci-operator config: ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-3.10.yaml
- Adds generated presubmit job definitions (ci-operator/jobs/...-standalone-distributed-tracing-3.10-presubmits.yaml) so the jobs run on PRs targeting the new branch.

Practical effect
- Pull requests against the standalone-distributed-tracing-3.10 branch will trigger two validation jobs:
  - validate-asciidoc: runs the AsciiDoc doc build/lint/preview steps using multiple openshift-docs build refs (build-docs, preview-comment-pages, asciidoctor, lint-topicmaps, jira-links, vale-review) with DISTROS=openshift-distributed-tracing and PREVIEW_SITE=ocpdocs-pr.
  - validate-portal: builds the documentation portal for the distributed tracing 3.10 docs (runs build_for_portal.py with DISTROS=openshift-distributed-tracing and VERSION="3.10", using the openshift-docs-portal ref).

Technical details
- build_root uses the ocp image stream tag openshift-docs-asciidoc:latest
- build caching is enabled (use_build_cache: true)
- Uniform resource settings applied to containers: 4Gi memory limit; requests: 400m CPU and 800Mi memory
- zz_generated_metadata maps the branch standalone-distributed-tracing-3.10 to org: openshift, repo: openshift-docs

The change wires the new release branch into the documentation CI pipeline so PRs are automatically validated for docs syntax/build and portal generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->