### PR TITLE
RHIDP-13099: configure HTPasswd identity provider on ephemeral cluster for broader team access [debug]

### DIFF
--- a/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
@@ -102,7 +102,10 @@ if ! timeout --foreground 5m bash -c '
 fi
 
 echo "========== HTPasswd Identity Provider =========="
-if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
+PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
+if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[setup-htpasswd]"* ]]; then
+    echo "Skipping HTPasswd identity provider setup. Add [setup-htpasswd] to PR title to enable."
+elif [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else
     htpasswd -c -B -i users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" <<< "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"

--- a/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
@@ -101,11 +101,17 @@ if ! timeout --foreground 5m bash -c '
     exit 1
 fi
 
-htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
-oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
-oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
-oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
-oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+echo "========== HTPasswd Identity Provider =========="
+if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
+    echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
+else
+    htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+    oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
+    rm -f users.htpasswd
+    oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
+    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+    oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+fi
 
 # ── Service account & platform info ──────────────────────────────────────────
 

--- a/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
@@ -101,6 +101,12 @@ if ! timeout --foreground 5m bash -c '
     exit 1
 fi
 
+htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
+oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
+oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+
 # ── Service account & platform info ──────────────────────────────────────────
 
 export K8S_CLUSTER_URL K8S_CLUSTER_TOKEN

--- a/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
@@ -102,9 +102,10 @@ if ! timeout --foreground 5m bash -c '
 fi
 
 echo "========== HTPasswd Identity Provider =========="
+# HTPasswd setup is opt-in via [debug] in the PR title — auth pod restarts add significant job time
 PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
-if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[setup-htpasswd]"* ]]; then
-    echo "Skipping HTPasswd identity provider setup. Add [setup-htpasswd] to PR title to enable."
+if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[debug]"* ]]; then
+    echo "Skipping HTPasswd identity provider setup. Add [debug] to PR title to enable."
 elif [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else

--- a/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
@@ -111,6 +111,7 @@ else
     oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
     oc wait --for=condition=Progressing=False clusteroperator/authentication --timeout=10m
     oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
+    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 

--- a/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh-plugin-export-overlays/ocp/helm/redhat-developer-rhdh-plugin-export-overlays-ocp-helm-commands.sh
@@ -105,11 +105,12 @@ echo "========== HTPasswd Identity Provider =========="
 if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else
-    htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+    htpasswd -c -B -i users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" <<< "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
     oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
     rm -f users.htpasswd
     oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
-    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+    oc wait --for=condition=Progressing=False clusteroperator/authentication --timeout=10m
+    oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
@@ -89,11 +89,17 @@ if ! oc wait --for=condition=Ready nodes --all --timeout=300s; then
 fi
 echo "All nodes are ready"
 
-htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
-oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
-oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
-oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
-oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+echo "========== HTPasswd Identity Provider =========="
+if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
+    echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
+else
+    htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+    oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
+    rm -f users.htpasswd
+    oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
+    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+    oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+fi
 
 echo "========== Cluster Service Account and Token Management =========="
 export K8S_CLUSTER_URL K8S_CLUSTER_TOKEN

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
@@ -89,6 +89,12 @@ if ! oc wait --for=condition=Ready nodes --all --timeout=300s; then
 fi
 echo "All nodes are ready"
 
+htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
+oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
+oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+
 echo "========== Cluster Service Account and Token Management =========="
 export K8S_CLUSTER_URL K8S_CLUSTER_TOKEN
 K8S_CLUSTER_URL=$(oc whoami --show-server)

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
@@ -90,7 +90,10 @@ fi
 echo "All nodes are ready"
 
 echo "========== HTPasswd Identity Provider =========="
-if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
+PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
+if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[setup-htpasswd]"* ]]; then
+    echo "Skipping HTPasswd identity provider setup. Add [setup-htpasswd] to PR title to enable."
+elif [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else
     htpasswd -c -B -i users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" <<< "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
@@ -90,9 +90,10 @@ fi
 echo "All nodes are ready"
 
 echo "========== HTPasswd Identity Provider =========="
+# HTPasswd setup is opt-in via [debug] in the PR title — auth pod restarts add significant job time
 PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
-if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[setup-htpasswd]"* ]]; then
-    echo "Skipping HTPasswd identity provider setup. Add [setup-htpasswd] to PR title to enable."
+if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[debug]"* ]]; then
+    echo "Skipping HTPasswd identity provider setup. Add [debug] to PR title to enable."
 elif [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
@@ -99,6 +99,7 @@ else
     oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
     oc wait --for=condition=Progressing=False clusteroperator/authentication --timeout=10m
     oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
+    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/nightly/redhat-developer-rhdh-ocp-helm-nightly-commands.sh
@@ -93,11 +93,12 @@ echo "========== HTPasswd Identity Provider =========="
 if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else
-    htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+    htpasswd -c -B -i users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" <<< "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
     oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
     rm -f users.htpasswd
     oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
-    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+    oc wait --for=condition=Progressing=False clusteroperator/authentication --timeout=10m
+    oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
@@ -124,19 +124,21 @@ else
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 
-echo "========== [TMP] HTPasswd Login Verification =========="
-echo "OAuth identity providers:"
-oc get oauth cluster -o jsonpath='{.spec.identityProviders}' | jq .
-echo "Authentication pods:"
-oc get pods -n openshift-authentication
-echo "Attempting login as EPHEMERAL_CLUSTER_ADMIN_USERNAME..."
-oc login "$(oc whoami --show-server)" \
-    --username "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" \
-    --password "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)" \
-    --insecure-skip-tls-verify=true && echo "Login successful" || echo "Login failed"
-echo "Current user: $(oc whoami)"
-echo "========== [TMP] Exiting early for rehearsal =========="
-exit 0
+PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
+if echo "${PR_TITLE}" | grep -qF '[verify-htpasswd]'; then
+    echo "========== HTPasswd Login Verification =========="
+    echo "OAuth identity providers:"
+    oc get oauth cluster -o jsonpath='{.spec.identityProviders}' | jq .
+    echo "Authentication pods:"
+    oc get pods -n openshift-authentication
+    echo "Attempting login as EPHEMERAL_CLUSTER_ADMIN_USERNAME..."
+    oc login "$(oc whoami --show-server)" \
+        --username "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" \
+        --password "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)" \
+        --insecure-skip-tls-verify=true && echo "Login successful" || echo "Login failed"
+    echo "Current user: $(oc whoami)"
+    exit 0
+fi
 
 echo "========== Cluster Service Account and Token Management =========="
 export K8S_CLUSTER_URL K8S_CLUSTER_TOKEN

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
@@ -114,11 +114,12 @@ echo "========== HTPasswd Identity Provider =========="
 if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else
-    htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+    htpasswd -c -B -i users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" <<< "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
     oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
     rm -f users.htpasswd
     oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
-    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+    oc wait --for=condition=Progressing=False clusteroperator/authentication --timeout=10m
+    oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
@@ -111,7 +111,10 @@ fi
 echo "All nodes are ready"
 
 echo "========== HTPasswd Identity Provider =========="
-if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
+PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
+if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[setup-htpasswd]"* ]]; then
+    echo "Skipping HTPasswd identity provider setup. Add [setup-htpasswd] to PR title to enable."
+elif [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else
     htpasswd -c -B -i users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" <<< "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
@@ -122,22 +125,6 @@ else
     oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
     oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
-fi
-
-PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
-if echo "${PR_TITLE}" | grep -qF '[verify-htpasswd]'; then
-    echo "========== HTPasswd Login Verification =========="
-    echo "OAuth identity providers:"
-    oc get oauth cluster -o jsonpath='{.spec.identityProviders}' | jq .
-    echo "Authentication pods:"
-    oc get pods -n openshift-authentication
-    echo "Attempting login as EPHEMERAL_CLUSTER_ADMIN_USERNAME..."
-    oc login "$(oc whoami --show-server)" \
-        --username "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" \
-        --password "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)" \
-        --insecure-skip-tls-verify=true && echo "Login successful" || echo "Login failed"
-    echo "Current user: $(oc whoami)"
-    exit 0
 fi
 
 echo "========== Cluster Service Account and Token Management =========="

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
@@ -110,11 +110,17 @@ if ! oc wait --for=condition=Ready nodes --all --timeout=300s; then
 fi
 echo "All nodes are ready"
 
-htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
-oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
-oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
-oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
-oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+echo "========== HTPasswd Identity Provider =========="
+if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
+    echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
+else
+    htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+    oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
+    rm -f users.htpasswd
+    oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
+    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+    oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+fi
 
 echo "========== Cluster Service Account and Token Management =========="
 export K8S_CLUSTER_URL K8S_CLUSTER_TOKEN

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
@@ -120,6 +120,7 @@ else
     oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
     oc wait --for=condition=Progressing=False clusteroperator/authentication --timeout=10m
     oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
+    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
@@ -111,9 +111,10 @@ fi
 echo "All nodes are ready"
 
 echo "========== HTPasswd Identity Provider =========="
+# HTPasswd setup is opt-in via [debug] in the PR title — auth pod restarts add significant job time
 PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
-if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[setup-htpasswd]"* ]]; then
-    echo "Skipping HTPasswd identity provider setup. Add [setup-htpasswd] to PR title to enable."
+if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[debug]"* ]]; then
+    echo "Skipping HTPasswd identity provider setup. Add [debug] to PR title to enable."
 elif [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
@@ -124,6 +124,20 @@ else
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 
+echo "========== [TMP] HTPasswd Login Verification =========="
+echo "OAuth identity providers:"
+oc get oauth cluster -o jsonpath='{.spec.identityProviders}' | jq .
+echo "Authentication pods:"
+oc get pods -n openshift-authentication
+echo "Attempting login as EPHEMERAL_CLUSTER_ADMIN_USERNAME..."
+oc login "$(oc whoami --show-server)" \
+    --username "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" \
+    --password "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)" \
+    --insecure-skip-tls-verify=true && echo "Login successful" || echo "Login failed"
+echo "Current user: $(oc whoami)"
+echo "========== [TMP] Exiting early for rehearsal =========="
+exit 0
+
 echo "========== Cluster Service Account and Token Management =========="
 export K8S_CLUSTER_URL K8S_CLUSTER_TOKEN
 K8S_CLUSTER_URL=$(oc whoami --show-server)

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/redhat-developer-rhdh-ocp-helm-commands.sh
@@ -110,6 +110,12 @@ if ! oc wait --for=condition=Ready nodes --all --timeout=300s; then
 fi
 echo "All nodes are ready"
 
+htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
+oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
+oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+
 echo "========== Cluster Service Account and Token Management =========="
 export K8S_CLUSTER_URL K8S_CLUSTER_TOKEN
 K8S_CLUSTER_URL=$(oc whoami --show-server)

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
@@ -90,7 +90,10 @@ fi
 echo "All nodes are ready"
 
 echo "========== HTPasswd Identity Provider =========="
-if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
+PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
+if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[setup-htpasswd]"* ]]; then
+    echo "Skipping HTPasswd identity provider setup. Add [setup-htpasswd] to PR title to enable."
+elif [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else
     htpasswd -c -B -i users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" <<< "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
@@ -81,12 +81,6 @@ EOF
     exit 1
 fi
 
-htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
-oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
-oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
-oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
-oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
-
 echo "========== Cluster Health Check =========="
 echo "Waiting for all nodes to be ready..."
 if ! oc wait --for=condition=Ready nodes --all --timeout=300s; then
@@ -94,6 +88,18 @@ if ! oc wait --for=condition=Ready nodes --all --timeout=300s; then
     exit 1
 fi
 echo "All nodes are ready"
+
+echo "========== HTPasswd Identity Provider =========="
+if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
+    echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
+else
+    htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+    oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
+    rm -f users.htpasswd
+    oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
+    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+    oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+fi
 
 echo "========== Cluster Service Account and Token Management =========="
 export K8S_CLUSTER_URL K8S_CLUSTER_TOKEN

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
@@ -81,6 +81,12 @@ EOF
     exit 1
 fi
 
+htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
+oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
+oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
+
 echo "========== Cluster Health Check =========="
 echo "Waiting for all nodes to be ready..."
 if ! oc wait --for=condition=Ready nodes --all --timeout=300s; then

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
@@ -90,9 +90,10 @@ fi
 echo "All nodes are ready"
 
 echo "========== HTPasswd Identity Provider =========="
+# HTPasswd setup is opt-in via [debug] in the PR title — auth pod restarts add significant job time
 PR_TITLE=$(echo "${JOB_SPEC}" | jq -r '.refs.pulls[0].title // empty')
-if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[setup-htpasswd]"* ]]; then
-    echo "Skipping HTPasswd identity provider setup. Add [setup-htpasswd] to PR title to enable."
+if [[ "$JOB_TYPE" != "periodic" ]] && [[ "$PR_TITLE" != *"[debug]"* ]]; then
+    echo "Skipping HTPasswd identity provider setup. Add [debug] to PR title to enable."
 elif [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
@@ -99,6 +99,7 @@ else
     oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
     oc wait --for=condition=Progressing=False clusteroperator/authentication --timeout=10m
     oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
+    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 

--- a/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
+++ b/ci-operator/step-registry/redhat-developer/rhdh/ocp/helm/upgrade/nightly/redhat-developer-rhdh-ocp-helm-upgrade-nightly-commands.sh
@@ -93,11 +93,12 @@ echo "========== HTPasswd Identity Provider =========="
 if [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME ]] || [[ ! -f /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD ]]; then
     echo "WARNING: EPHEMERAL_CLUSTER_ADMIN_* secrets not found, skipping HTPasswd identity provider setup"
 else
-    htpasswd -c -B -b users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
+    htpasswd -c -B -i users.htpasswd "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)" <<< "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_PASSWORD)"
     oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd -n openshift-config
     rm -f users.htpasswd
     oc patch oauth cluster --type=merge --patch='{"spec":{"identityProviders":[{"name":"cluster_admin","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"htpass-secret"}}}]}}'
-    oc wait --for=condition=Ready pod --all -n openshift-authentication --timeout=400s
+    oc wait --for=condition=Progressing=False clusteroperator/authentication --timeout=10m
+    oc wait --for=condition=Available=True clusteroperator/authentication --timeout=10m
     oc adm policy add-cluster-role-to-user cluster-admin "$(cat /tmp/secrets/EPHEMERAL_CLUSTER_ADMIN_USERNAME)"
 fi
 


### PR DESCRIPTION
**Jira:** [RHIDP-13099](https://redhat.atlassian.net/browse/RHIDP-13099)

## Summary

Allow everyone in the RHDH team to log in to a claimed cluster from a cluster pool for jobs running in the `rhdh` repository. This helps CI Medics and team members investigate E2E test failures without needing `rhdh-pool-admins` group membership.

This PR covers the **step-registry** side: configuring an HTPasswd identity provider on the ephemeral cluster during CI setup so a named cluster-admin user (from Vault) is available for login.

- Creates an HTPasswd identity provider backed by `EPHEMERAL_CLUSTER_ADMIN_USERNAME` / `EPHEMERAL_CLUSTER_ADMIN_PASSWORD` Vault secrets
- Registers the user as `cluster-admin` so they have full access for investigation
- Waits for authentication pods to be ready before proceeding

The companion change in `redhat-developer/rhdh` updates `ocp-cluster-claim-login.sh` to use these credentials directly via Vault OIDC, removing the need for `oc login --web` to hosted-mgmt.

## Test plan

- [ ] Verify `htpass-secret` is created in `openshift-config` namespace on ephemeral cluster
- [ ] Verify `oc login` succeeds with the HTPasswd credentials after `oc wait` for authentication pods
- [ ] Verify existing kubeadmin-based login flow (service account token) is unaffected
- [ ] Rehearse the job to confirm no regression in pr-check and nightly modes

Assisted-by: Claude Code

[RHIDP-13099]: https://redhat.atlassian.net/browse/RHIDP-13099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ