### PR TITLE
RHDH: route Prow reporter_config to per-release Slack channels

### DIFF
--- a/ci-operator/config/redhat-developer/rhdh/CLAUDE.md
+++ b/ci-operator/config/redhat-developer/rhdh/CLAUDE.md
@@ -74,10 +74,11 @@ When creating a new release branch (e.g., `release-1.11`):
 
 ### Slack Webhook
 
-1. Create a new Slack channel following the established naming scheme (see existing channels in the [Nightly Test Alerts Slack app](https://api.slack.com/apps/A08U4AP1YTY/incoming-webhooks) for reference).
+1. Create a new Slack channel named `#rhdh-e2e-alerts-X-Y` (e.g., `#rhdh-e2e-alerts-1-11` for `release-1.11`). See existing channels in the [Nightly Test Alerts Slack app](https://api.slack.com/apps/A08U4AP1YTY/incoming-webhooks) for reference.
 2. In the same Slack app, create a new incoming webhook for the newly created channel.
 3. Store the webhook URL in the vault as `SLACK_ALERTS_WEBHOOK_URL_X_Y` (e.g., `SLACK_ALERTS_WEBHOOK_URL_1_11` for `release-1.11`).
 4. The `redhat-developer-rhdh-send-alert` step automatically detects the release version from `JOB_NAME` and looks for the versioned webhook file at `/tmp/secrets/SLACK_ALERTS_WEBHOOK_URL_X_Y`. If not found, it falls back to `/tmp/secrets/SLACK_ALERTS_WEBHOOK_URL`.
+5. Update the `reporter_config.channel` in the new release CI config YAML to use `#rhdh-e2e-alerts-X-Y` (e.g., `#rhdh-e2e-alerts-1-11`). This is the Prow-level Slack reporter — separate from the `send-alert` step — that fires on CI infrastructure errors and (for `auth-providers` and `upgrade` tests) on success/failure. The `main` branch uses `#rhdh-e2e-alerts`.
 
 ### Job Concurrency
 

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8.yaml
@@ -53,7 +53,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -82,7 +82,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -113,7 +113,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -144,7 +144,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -167,7 +167,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -190,7 +190,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -213,7 +213,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -236,7 +236,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -259,7 +259,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -278,7 +278,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -305,7 +305,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -325,7 +325,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -347,7 +347,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -379,7 +379,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-8'
     job_states_to_report:
     - success
     - failure

--- a/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
+++ b/ci-operator/config/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9.yaml
@@ -53,7 +53,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -82,7 +82,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -113,7 +113,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -144,7 +144,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -175,7 +175,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -198,7 +198,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -221,7 +221,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -244,7 +244,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -267,7 +267,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -290,7 +290,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -309,7 +309,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -336,7 +336,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -356,7 +356,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -378,7 +378,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - error
     report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -409,7 +409,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - success
     - failure
@@ -440,7 +440,7 @@ tests:
   optional: true
   presubmit: true
   reporter_config:
-    channel: '#rhdh-e2e-alerts'
+    channel: '#rhdh-e2e-alerts-1-9'
     job_states_to_report:
     - success
     - failure

--- a/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8-periodics.yaml
+++ b/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-1.8-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-aks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -100,7 +100,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-aks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -185,7 +185,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-eks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -270,7 +270,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-eks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -355,7 +355,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-gke-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -440,7 +440,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-gke-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -525,7 +525,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -617,7 +617,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-operator-auth-providers-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - success
       - failure
@@ -714,7 +714,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -806,7 +806,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-v4-16-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -898,7 +898,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-v4-19-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -990,7 +990,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-v4-20-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1082,7 +1082,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-osd-gcp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1167,7 +1167,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.8-e2e-osd-gcp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-8'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`

--- a/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9-periodics.yaml
+++ b/ci-operator/jobs/redhat-developer/rhdh/redhat-developer-rhdh-release-1.9-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-aks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -100,7 +100,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-aks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -185,7 +185,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-eks-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -270,7 +270,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-eks-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -355,7 +355,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-gke-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -440,7 +440,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-gke-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -525,7 +525,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -617,7 +617,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-helm-upgrade-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - success
       - failure
@@ -714,7 +714,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-operator-auth-providers-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - success
       - failure
@@ -811,7 +811,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -903,7 +903,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-v4-16-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -995,7 +995,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-v4-19-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1087,7 +1087,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-v4-20-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1179,7 +1179,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-ocp-v4-21-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1271,7 +1271,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-osd-gcp-helm-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`
@@ -1356,7 +1356,7 @@ periodics:
   name: periodic-ci-redhat-developer-rhdh-release-1.9-e2e-osd-gcp-operator-nightly
   reporter_config:
     slack:
-      channel: '#rhdh-e2e-alerts'
+      channel: '#rhdh-e2e-alerts-1-9'
       job_states_to_report:
       - error
       report_template: '<!subteam^S07BMJ56R8S> <@U08UP0REWG1> :failed: `{{.Spec.Job}}`


### PR DESCRIPTION
## Summary

- Route release branch Prow Slack reporter notifications to dedicated per-release channels (`#rhdh-e2e-alerts-1-8`, `#rhdh-e2e-alerts-1-9`) instead of the shared `#rhdh-e2e-alerts` channel
- The `main` branch continues to use `#rhdh-e2e-alerts`
- Update `CLAUDE.md` new release branch checklist to document the `reporter_config` channel naming convention

## Context

The `.config.prowgen` file [is deprecated](https://redhat-internal.slack.com/archives/CFUGK0K9R/p1778658277948789) and all functionality has moved to per-test `reporter_config` fields in ci-operator config YAML. RHDH was already migrated in #78976.

Previously, the centralized `.config.prowgen` `slack_reporter` could not route different jobs to different channels (documented in #76593). The per-test `reporter_config` model removes that limitation, allowing each release branch to use its own Slack channel.

Jira: https://redhat.atlassian.net/browse/RHIDP-13582