### PR TITLE
feat: enable PRPQR garbage collection with 30-day retention

### DIFF
--- a/clusters/app.ci/job-trigger-controller-manager/admin_job-trigger-controller-manager_rbac.yaml
+++ b/clusters/app.ci/job-trigger-controller-manager/admin_job-trigger-controller-manager_rbac.yaml
@@ -14,6 +14,7 @@ rules:
   resources:
   - pullrequestpayloadqualificationruns
   verbs:
+  - delete
   - get
   - list
   - update

--- a/clusters/app.ci/job-trigger-controller-manager/job-trigger-controller-manager_deploy.yaml
+++ b/clusters/app.ci/job-trigger-controller-manager/job-trigger-controller-manager_deploy.yaml
@@ -37,6 +37,7 @@ spec:
         - --supplemental-prow-config-dir=/etc/config
         - --aggregator-job-timeout=8
         - --multi-ref-job-timeout=8
+        - --max-prpqr-age=720h
         volumeMounts:
           - name: config
             mountPath: /etc/config


### PR DESCRIPTION
/hold
/cc @openshift/test-platform 

https://github.com/openshift/ci-tools/pull/5178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Enables PRPQR garbage collection in the app.ci cluster (30-day retention)

This PR configures OpenShift CI's app.ci cluster so the job-trigger-controller-manager can garbage collect old PullRequestPayloadQualificationRun (PRPQR) objects, and sets the retention period to 720 hours (30 days).

### Changes made
- RBAC: Grants the ClusterRole job-trigger-controller-manager-prpqr the `delete` verb for `pullrequestpayloadqualificationruns.ci.openshift.io`, allowing the controller to remove aged PRPQRs.
- Controller configuration: Adds the container argument `--max-prpqr-age=720h` to the job-trigger-controller-manager Deployment in the app.ci cluster, making PRPQRs older than 720 hours eligible for deletion.

### Additional notes
- The PR includes a hold directive ("/hold") and a cc to the test-platform team ("/cc @openshift/test-platform").
- This change is coordinated with a corresponding ci-tools update that implements the GC logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->