### PR TITLE
Extend timeout for e2e tests

### DIFF
--- a/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-ref.yaml
+++ b/ci-operator/step-registry/servicemesh/sail-operator/e2e-ocp/servicemesh-sail-operator-e2e-ocp-ref.yaml
@@ -9,7 +9,7 @@ ref:
   - mount_path: /tmp/secrets
     name: quay-sail
     namespace: test-credentials
-  timeout: 2h0m0s
+  timeout: 3h0m0s
   commands: servicemesh-sail-operator-e2e-ocp-commands.sh
   env:
   - name: MAISTRA_NAMESPACE


### PR DESCRIPTION
The issue of pod crash might be related with overall timeout https://github.com/istio-ecosystem/sail-operator/issues/1898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR extends the timeout for the servicemesh sail-operator end-to-end (e2e) tests in the OpenShift CI infrastructure. Specifically, it increases the `timeout` parameter for the `servicemesh-sail-operator-e2e-ocp` test step from 2 hours to 3 hours, allowing these tests additional time to complete before being terminated by the CI system.

This adjustment affects the E2E testing pipeline for the sail-operator component and indicates that the tests were previously timing out or needed more buffer time to reliably complete within the OpenShift CI environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->