### PR TITLE
prefer non-highmem nodes for CI pods to reserve r5.4xlarge capacity for pj-rehearse-plugin

### DIFF
--- a/clusters/app.ci/assets/dptp-controller-manager.yaml
+++ b/clusters/app.ci/assets/dptp-controller-manager.yaml
@@ -115,6 +115,16 @@ spec:
       tolerations:
       - key: manual-provision
         operator: Exists
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                - r5.4xlarge
       initContainers:
       - name: git-sync-init
         command:

--- a/clusters/app.ci/assets/slack-bot.yaml
+++ b/clusters/app.ci/assets/slack-bot.yaml
@@ -67,6 +67,16 @@ spec:
         app: slack-bot
     spec:
       serviceAccountName: slack-bot
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                - r5.4xlarge
       initContainers:
       - name: git-sync-init
         command:

--- a/clusters/app.ci/ci-operator-configresolver/ci-operator-configresolver.yaml
+++ b/clusters/app.ci/ci-operator-configresolver/ci-operator-configresolver.yaml
@@ -135,6 +135,15 @@ spec:
         component: ci-operator-configresolver
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                - r5.4xlarge
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100

--- a/clusters/app.ci/prow/03_deployment/pj-rehearse-plugin.yaml
+++ b/clusters/app.ci/prow/03_deployment/pj-rehearse-plugin.yaml
@@ -140,3 +140,10 @@ spec:
                 operator: In
                 values:
                 - r5.4xlarge
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: prow
+                component: pj-rehearse-plugin
+            topologyKey: kubernetes.io/hostname

--- a/clusters/app.ci/prow/03_deployment/publicize.yaml
+++ b/clusters/app.ci/prow/03_deployment/publicize.yaml
@@ -39,6 +39,16 @@ spec:
         app: prow
         component: publicize
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                - r5.4xlarge
       containers:
       - name: publicize
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_publicize_latest

--- a/clusters/app.ci/prow/03_deployment/retester.yaml
+++ b/clusters/app.ci/prow/03_deployment/retester.yaml
@@ -44,6 +44,16 @@ spec:
         app: prow
         component: retester
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                - r5.4xlarge
       initContainers:
       - name: git-sync-init
         command:

--- a/clusters/app.ci/prow/03_deployment/tot.yaml
+++ b/clusters/app.ci/prow/03_deployment/tot.yaml
@@ -54,6 +54,16 @@ spec:
         app: prow
         component: tot
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: NotIn
+                values:
+                - r5.4xlarge
       initContainers:
       - name: git-sync-init
         command:


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Scheduling affinity changes to reserve r5.4xlarge capacity for pj-rehearse-plugin

This PR implements scheduling affinity rules across multiple OpenShift CI infrastructure deployments to ensure that r5.4xlarge (high-memory) nodes are reserved for the pj-rehearse-plugin workload, which requires that capacity.

### Changes made

**Deployments updated with node affinity preferences to avoid r5.4xlarge nodes:**
- `dptp-controller-manager`
- `slack-bot`
- `ci-operator-configresolver`
- `publicize`
- `retester`
- `tot`

Each of these deployments now includes a `nodeAffinity` preference rule (using `preferredDuringSchedulingIgnoredDuringExecution` with weight 100) that schedules pods away from `r5.4xlarge` instance types, allowing those nodes to remain available for higher-priority workloads.

**pj-rehearse-plugin enhanced with pod anti-affinity:**
The `pj-rehearse-plugin` Deployment receives an added `podAntiAffinity` rule requiring pods with matching labels (`app: prow`, `component: pj-rehearse-plugin`) to be scheduled on different nodes (using hostname as the topology key), improving availability and distribution of this critical plugin.

### Impact

These changes improve CI infrastructure resource utilization by directing regular CI operations to smaller node types while reserving the larger r5.4xlarge capacity for the pj-rehearse-plugin, which depends on that memory-intensive instance type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->