### PR TITLE
DPTP-2938: pod-scaler set --max-data-age=504h (21 days) for producer

### DIFF
--- a/clusters/app.ci/pod-scaler/pod-scaler.yaml
+++ b/clusters/app.ci/pod-scaler/pod-scaler.yaml
@@ -33,6 +33,7 @@ spec:
         - --cache-bucket=origin-ci-resource-usage-data-v2
         - --gcs-credentials-file=/etc/gcs/service-account.json
         - --mode=producer
+        - --max-data-age=504h
         - --kubeconfig-dir=/var/kubeconfigs
         - --kubeconfig-suffix=config
         ports:


### PR DESCRIPTION
/hold
/cc @openshift/test-platform 

https://github.com/openshift/ci-tools/pull/5182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updates the `pod-scaler-producer` component configuration in the OpenShift CI `app.ci` cluster infrastructure to enforce a maximum data age window of 504 hours (21 days) when analyzing resource usage patterns.

## Changes

**clusters/app.ci/pod-scaler/pod-scaler.yaml**

Added `--max-data-age=504h` flag to the `pod-scaler-producer` Deployment's container arguments. The pod-scaler producer is responsible for collecting and analyzing CI workload resource usage data from Google Cloud Storage to generate resource scaling recommendations. This parameter limits the historical data window considered during analysis to only the most recent 21 days of metrics.

## Impact

This configuration change applies to the resource scaling analysis performed on the `app.ci` cluster infrastructure, ensuring that scaling decisions are based on recent usage patterns rather than older historical data that may not reflect current workload characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->