### PR TITLE
Update odf release 4.21.5

### DIFF
--- a/core-services/jira-lifecycle-plugin/config.yaml
+++ b/core-services/jira-lifecycle-plugin/config.yaml
@@ -1121,10 +1121,10 @@ orgs:
         target_version: odf-4.20.12
         validate_by_default: true
       release-4.21:
-        target_version: odf-4.21.3
+        target_version: odf-4.21.5
         validate_by_default: true
       release-4.21-compatibility:
-        target_version: odf-4.21.3
+        target_version: odf-4.21.5
         validate_by_default: true
       release-4.22:
         target_version: odf-4.22


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the OpenShift Data Foundation (ODF) target versions in the JIRA lifecycle plugin configuration. The `release-4.21` and `release-4.21-compatibility` branches now have their `target_version` set to `odf-4.21.5`, reflecting a patch release update from version 4.21.3.

This configuration change affects how issues and bugs are tracked in JIRA when merged into the ODF release branches. The target version is used to automatically populate the correct version field in JIRA when pull requests are merged, ensuring proper issue lifecycle management for the 4.21 release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->