### PR TITLE
telco5g: Wait until all operators are up before tests

### DIFF
--- a/ci-operator/step-registry/telco5g/cnf/tests/telco5g-cnf-tests-commands.sh
+++ b/ci-operator/step-registry/telco5g/cnf/tests/telco5g-cnf-tests-commands.sh
@@ -754,6 +754,30 @@ val_status=0
 if [[ -n "$skip_tests" ]]; then
     export SKIP_TESTS="${skip_tests}"
 fi
+if [[ "$T5CI_JOB_TYPE" != "hcp-cnftests" ]] && [[ "$T5CI_JOB_TYPE" != "sno-ztp-cnftests" ]]; then
+    echo "Wait until number of nodes matches number of machines"
+    for _ in $(seq 30); do
+        nodes="$(oc get nodes --no-headers | wc -l)"
+        machines="$(oc get machines -A --no-headers | wc -l)"
+        [ "$machines" -le "$nodes" ] && break
+        sleep 30
+    done
+    echo "Check if nodes amount '$nodes' equal to machines '$machines'"
+    [ "$machines" -le "$nodes" ]
+fi
+
+echo "Wait for MachineConfigPools to finish updating (verifies node reboots are complete)"
+oc wait mcp --all --for='condition=UPDATED=True' --timeout=30m || echo "WARNING: not all MachineConfigPools have UPDATED=True after 30m"
+oc wait mcp --all --for='condition=UPDATING=False' --timeout=30m || echo "WARNING: some MachineConfigPools still UPDATING after 30m"
+
+echo "Wait for nodes to be up and ready"
+oc wait nodes --all --for=condition=Ready=true --timeout=10m || echo "WARNING: not all nodes are Ready after 10m"
+
+echo "Wait for cluster operators to be deployed and ready"
+oc wait clusteroperators --all --for=condition=Progressing=false --timeout=15m || echo "WARNING: some cluster operators still Progressing after 15m"
+oc wait clusteroperators --all --for=condition=Available=true --timeout=15m || echo "WARNING: not all cluster operators are Available after 15m"
+oc wait clusteroperators --all --for=condition=Degraded=false --timeout=15m || echo "WARNING: some cluster operators are Degraded after 15m"
+
 # if RUN_VALIDATIONS set, run validations
 if $RUN_VALIDATIONS; then
     echo "************ Running validations ************"
@@ -764,32 +788,6 @@ if [[ ${val_status} -ne 0 ]]; then
     echo "Validations failed with status code $val_status"
     status=${val_status}
 fi
-
-if [[ "$T5CI_JOB_TYPE" != "hcp-cnftests" ]] && [[ "$T5CI_JOB_TYPE" != "sno-ztp-cnftests" ]]; then
-    echo "Wait until number of nodes matches number of machines"
-    # Wait until number of nodes matches number of machines
-    # Ref.: https://github.com/openshift/release/blob/master/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
-    for _ in $(seq 30); do
-        nodes="$(oc get nodes --no-headers | wc -l)"
-        machines="$(oc get machines -A --no-headers | wc -l)"
-        [ "$machines" -le "$nodes" ] && break
-        sleep 30
-    done
-
-
-    echo "Check if nodes amount '$nodes' equal to machines '$machines'"
-    [ "$machines" -le "$nodes" ]
-
-fi
-echo "Wait for nodes to be up and ready"
-# Wait for nodes to be ready
-# Ref.: https://github.com/openshift/release/blob/master/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
-oc wait nodes --all --for=condition=Ready=true --timeout=10m
-
-echo "Wait for cluster operators to be deployed and ready"
-# Waiting for clusteroperators to finish progressing
-# Ref.: https://github.com/openshift/release/blob/master/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh
-oc wait clusteroperators --all --for=condition=Progressing=false --timeout=10m
 
 # if validations passed and RUN_TESTS set, run the tests
 if [[ ${val_status} -eq 0 ]] && $RUN_TESTS; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Telco5G CNF Tests: Wait for cluster readiness before validations

This change modifies the telco5g CNF test step in the OpenShift CI infrastructure to ensure cluster components are fully ready before running test validations.

**What changed:** The sequence of readiness checks and validations in the telco5g CNF tests script (`ci-operator/step-registry/telco5g/cnf/tests/`) has been reordered to provide more robust cluster validation:

1. **Improved readiness verification** (now runs first):
   - Waits for OpenShift nodes count to match the number of Machines
   - Waits for all MachineConfigPools to complete updates (`UPDATED=True` and `UPDATING=False`)
   - Waits for nodes to reach `Ready` state
   - Waits for cluster operators to be healthy (`Progressing=false`, `Available=true`, `Degraded=false`)

2. **Validations now run after readiness** (previously ran before):
   - Test validations (when `RUN_VALIDATIONS` is enabled) execute only after all cluster components are confirmed ready
   - The overall test status is set based on validation results

This change applies to the standard telco5g CNF test path, excluding specialized variants like HCP CNF tests and SNO ZTP CNF tests.

**Impact:** The telco5g CI testing will be more reliable by ensuring the cluster is in a fully ready state before running validations, reducing false failures due to transient cluster state issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->