### PR TITLE
ROSAENG-1091: rosa-regional-platform: consolidate CI entrypoints to step registry refs

### DIFF
--- a/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
@@ -41,57 +41,24 @@ tests:
 - as: nightly-ephemeral
   cron: 0 4 * * *
   steps:
-    post:
-    - as: teardown-ephemeral
-      commands: ./ci/nightly.sh --teardown
-      credentials:
-      - mount_path: /var/run/rosa-credentials
-        name: rosa-regional-platform-ephemeral-creds
-        namespace: test-credentials
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+    allow_best_effort_post_steps: true
+    env:
+      ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET: "false"
     pre:
-    - as: provision-ephemeral
-      commands: ./ci/nightly.sh
-      credentials:
-      - mount_path: /var/run/rosa-credentials
-        name: rosa-regional-platform-ephemeral-creds
-        namespace: test-credentials
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+    - ref: rosa-regional-platform-provision
     test:
-    - as: e2e
-      commands: ./ci/e2e-tests.sh
-      credentials:
-      - mount_path: /var/run/rosa-credentials
-        name: rosa-regional-platform-ephemeral-creds
-        namespace: test-credentials
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+    - ref: rosa-regional-platform-e2e
+    post:
+    - ref: rosa-regional-platform-teardown
 - as: nightly-integration
   cron: 0 4 * * *
   steps:
     test:
-    - as: e2e
-      commands: ./ci/e2e-tests.sh
+    - ref: rosa-regional-platform-e2e
       credentials:
-      - mount_path: /var/run/rosa-credentials
+      - namespace: test-credentials
         name: rosa-regional-platform-integration-creds
-        namespace: test-credentials
-      from: src
-      resources:
-        requests:
-          cpu: 100m
-          memory: 200Mi
+        mount_path: /var/run/rosa-credentials
 - always_run: false
   as: on-demand-e2e
   steps:
@@ -100,7 +67,8 @@ tests:
       commands: |-
         export REPOSITORY_URL=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq -r '.head.repo.clone_url')
         export REPOSITORY_BRANCH="${PULL_HEAD_REF}"
-        ./ci/nightly.sh --teardown-fire-and-forget
+        export AWS_CONFIG_FILE=/var/run/rosa-credentials/aws_config
+        uv run --no-cache ci/ephemeral-provider/main.py --teardown-fire-and-forget
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -115,7 +83,9 @@ tests:
       commands: |-
         export REPOSITORY_URL=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${PULL_NUMBER}" | jq -r '.head.repo.clone_url')
         export REPOSITORY_BRANCH="${PULL_HEAD_REF}"
-        ./ci/nightly.sh
+        export AWS_CONFIG_FILE=/var/run/rosa-credentials/aws_config
+        uv run --no-cache ci/ephemeral-provider/main.py \
+          --save-regional-state "${SHARED_DIR}/regional-terraform-outputs.json"
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds
@@ -127,7 +97,9 @@ tests:
           memory: 200Mi
     test:
     - as: e2e
-      commands: ./ci/e2e-tests.sh
+      commands: |-
+        export AWS_CONFIG_FILE=/var/run/rosa-credentials/aws_config
+        ./ci/e2e-tests.sh
       credentials:
       - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-ephemeral-creds

--- a/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
@@ -54,11 +54,19 @@ tests:
   cron: 0 4 * * *
   steps:
     test:
-    - ref: rosa-regional-platform-e2e
+    - as: e2e
+      commands: |-
+        export AWS_CONFIG_FILE=/var/run/rosa-credentials/aws_config
+        ./ci/e2e-tests.sh
       credentials:
-      - namespace: test-credentials
+      - mount_path: /var/run/rosa-credentials
         name: rosa-regional-platform-integration-creds
-        mount_path: /var/run/rosa-credentials
+        namespace: test-credentials
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
 - always_run: false
   as: on-demand-e2e
   steps:

--- a/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
+++ b/ci-operator/config/openshift-online/rosa-regional-platform/openshift-online-rosa-regional-platform-main.yaml
@@ -44,12 +44,12 @@ tests:
     allow_best_effort_post_steps: true
     env:
       ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET: "false"
+    post:
+    - ref: rosa-regional-platform-teardown
     pre:
     - ref: rosa-regional-platform-provision
     test:
     - ref: rosa-regional-platform-e2e
-    post:
-    - ref: rosa-regional-platform-teardown
 - as: nightly-integration
   cron: 0 4 * * *
   steps:

--- a/ci-operator/step-registry/rosa-regional-platform/e2e/rosa-regional-platform-e2e-ref.yaml
+++ b/ci-operator/step-registry/rosa-regional-platform/e2e/rosa-regional-platform-e2e-ref.yaml
@@ -15,6 +15,11 @@ ref:
     name: rosa-regional-platform-ephemeral-creds
     mount_path: /var/run/rosa-credentials
   env:
+  - name: AWS_CONFIG_FILE
+    default: "/var/run/rosa-credentials/aws_config"
+    documentation: |-
+      Path to the AWS CLI config file with named profiles from the mounted
+      credential secret.
   - name: ROSA_REGIONAL_PLATFORM_REF
     default: "main"
     documentation: |-

--- a/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-ref.yaml
+++ b/ci-operator/step-registry/rosa-regional-platform/provision/rosa-regional-platform-provision-ref.yaml
@@ -15,6 +15,11 @@ ref:
     name: rosa-regional-platform-ephemeral-creds
     mount_path: /var/run/rosa-credentials
   env:
+  - name: AWS_CONFIG_FILE
+    default: "/var/run/rosa-credentials/aws_config"
+    documentation: |-
+      Path to the AWS CLI config file with named profiles from the mounted
+      credential secret.
   - name: ROSA_REGIONAL_PLATFORM_REF
     default: "main"
     documentation: |-

--- a/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
+++ b/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-commands.sh
@@ -18,5 +18,10 @@ git clone https://github.com/openshift-online/rosa-regional-platform.git "${WORK
 cd "${WORK_DIR}/platform"
 git checkout "${CLONE_REF}"
 
-echo "Starting ephemeral teardown (fire-and-forget)..."
-uv run --no-cache ci/ephemeral-provider/main.py --teardown-fire-and-forget
+if [[ "${ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET:-true}" == "true" ]]; then
+  echo "Starting ephemeral teardown (fire-and-forget)..."
+  uv run --no-cache ci/ephemeral-provider/main.py --teardown-fire-and-forget
+else
+  echo "Starting ephemeral teardown (synchronous)..."
+  uv run --no-cache ci/ephemeral-provider/main.py --teardown
+fi

--- a/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-ref.yaml
+++ b/ci-operator/step-registry/rosa-regional-platform/teardown/rosa-regional-platform-teardown-ref.yaml
@@ -15,11 +15,22 @@ ref:
     name: rosa-regional-platform-ephemeral-creds
     mount_path: /var/run/rosa-credentials
   env:
+  - name: AWS_CONFIG_FILE
+    default: "/var/run/rosa-credentials/aws_config"
+    documentation: |-
+      Path to the AWS CLI config file with named profiles from the mounted
+      credential secret.
+  - name: ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET
+    default: "true"
+    documentation: |-
+      When "true", teardown runs asynchronously (fire-and-forget) so the job
+      finishes quickly. Set to "false" for full synchronous teardown (nightly jobs).
   - name: ROSA_REGIONAL_PLATFORM_REF
     default: "main"
     documentation: |-
       Git ref of openshift-online/rosa-regional-platform to clone for teardown.
   documentation: |-
     Tears down an ephemeral rosa-regional-platform environment provisioned
-    by the rosa-regional-platform-provision step. Uses fire-and-forget mode
-    so teardown does not block job completion.
+    by the rosa-regional-platform-provision step. Defaults to fire-and-forget
+    mode; set ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET=false for synchronous
+    teardown.


### PR DESCRIPTION
## Summary

- Migrate `nightly-ephemeral` and `nightly-integration` from inlined commands with duplicated credential blocks to step registry refs
- Simplify `on-demand-e2e` to call the ephemeral provider directly instead of via `nightly.sh`
- Add `AWS_CONFIG_FILE` env to provision, e2e, and teardown refs so AWS profiles are set automatically
- Add `ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET` env to teardown ref (default `true`, nightly overrides to `false` for synchronous teardown)

### Before
- Each nightly-ephemeral step inlined commands + credentials (3x duplication)
- All jobs called `nightly.sh` which just sourced `setup-aws-profiles.sh` and called the ephemeral provider

### After
- `nightly-ephemeral`: 3 step registry refs, no inline commands or credentials
- `nightly-integration`: 1 step registry ref with credential override
- `on-demand-e2e`: direct `ephemeral-provider/main.py` calls, no `nightly.sh` wrapper
- Credentials declared once per ref, not per job step

## Test plan
- [ ] `nightly-ephemeral` runs successfully at 04:00 UTC (provision → e2e → synchronous teardown)
- [ ] `nightly-integration` runs successfully at 04:00 UTC (e2e with integration-creds)
- [ ] `on-demand-e2e` triggered on a rosa-regional-platform PR provisions, tests, and tears down correctly
- [ ] Cross-component e2e workflow (`rosa-regional-platform-ephemeral-e2e`) still works (uses same refs)

/cc @typeid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Consolidate rosa-regional-platform CI entrypoints to step registry refs

This PR updates OpenShift CI configuration in openshift-online/rosa-regional-platform to centralize provisioning, testing, and teardown into step-registry refs, remove duplicated inline credential/command blocks, and make teardown behavior configurable.

### What changed (practical impact)
- Nightly ephemeral workflow (cron 04:00 UTC) now references step-registry refs instead of inline command blocks:
  - pre: rosa-regional-platform-provision
  - test: rosa-regional-platform-e2e
  - post: rosa-regional-platform-teardown
  - allow_best_effort_post_steps is enabled and the nightly job sets ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET="false" so teardown runs synchronously for ordered cleanup.
- nightly-integration remains an inline e2e step (cron 04:00 UTC) that explicitly sets AWS_CONFIG_FILE=/var/run/rosa-credentials/aws_config and runs ./ci/e2e-tests.sh — kept inline because the job needs per-step credential mounting that cannot be mixed with a step `ref`.
- on-demand-e2e (manual PR-triggered) no longer calls nightly.sh; its pre/test/post steps invoke the ephemeral provider and tests directly:
  - provision and teardown use uv run --no-cache ci/ephemeral-provider/main.py (provision saves regional state; teardown supports fire-and-forget by default)
  - test runs ./ci/e2e-tests.sh
  - each step exports AWS_CONFIG_FILE=/var/run/rosa-credentials/aws_config and uses the ephemeral credential secret.
- Credentials and AWS profile wiring are centralized in refs: provision, e2e, and teardown refs declare the ephemeral credential secret and an AWS_CONFIG_FILE env var (default /var/run/rosa-credentials/aws_config), removing per-step duplication.

### Step-ref enhancements
- rosa-regional-platform-provision and rosa-regional-platform-e2e refs:
  - add AWS_CONFIG_FILE (default /var/run/rosa-credentials/aws_config)
  - keep credential mount to test-credentials/rosa-regional-platform-ephemeral-creds
- rosa-regional-platform-teardown ref:
  - adds AWS_CONFIG_FILE and ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET (default "true")
  - the teardown script conditionally runs --teardown-fire-and-forget (default) or --teardown when ROSA_REGIONAL_TEARDOWN_FIRE_AND_FORGET=false; nightly overrides it to "false" for synchronous teardown.

### Benefits
- Eliminates duplicated credential mounts and AWS-profile setup across job steps by declaring them once per ref.
- Simplifies job YAML by replacing inline command blocks with concise refs.
- Makes teardown mode explicit and configurable (default async for quick jobs, synchronous for nightly ordered cleanup).
- on-demand-e2e is more direct and easier to debug by calling the ephemeral provider directly.

### Notes / Constraints
- nightly-integration remains inline because ci-operator cannot mix a step `ref` with per-step credentials; it explicitly exports AWS_CONFIG_FILE and mounts integration creds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->