### PR TITLE
ROSAENG-898: Add e2e smoke checks as required for rosa-e2e

### DIFF
--- a/core-services/prow/02_config/openshift-online/rosa-e2e/_prowconfig.yaml
+++ b/core-services/prow/02_config/openshift-online/rosa-e2e/_prowconfig.yaml
@@ -1,3 +1,12 @@
+branch-protection:
+  orgs:
+    openshift-online:
+      repos:
+        rosa-e2e:
+          required_status_checks:
+            contexts:
+            - ci/prow/e2e-rosa-classic-smoke
+            - ci/prow/e2e-rosa-hcp-smoke
 slack_reporter_configs:
   openshift-online/rosa-e2e:
     channel: '#ocm-fvt-prow'


### PR DESCRIPTION
## Summary

Add e2e smoke checks as required branch protection status checks for openshift-online/rosa-e2e so Dependabot PRs cannot auto-merge until both HCP and Classic STS smoke tests pass.

Required checks added:
- ci/prow/e2e-rosa-classic-smoke
- ci/prow/e2e-rosa-hcp-smoke

These checks use run_if_changed and trigger on go.mod/go.sum changes, which Dependabot PRs always include. Without this, Dependabot PRs auto-merge as soon as unit/lint pass, bypassing the e2e validation.

Jira: https://redhat.atlassian.net/browse/ROSAENG-898

## Test plan

- [ ] After merge, verify branch protection shows the smoke checks as required
- [ ] Next Dependabot PR should wait for smoke tests before auto-merging
