### PR TITLE
Remove STS conformance jobs for 4.23 and 5.0 (not available for Classic STS)

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-4.23.yaml
@@ -2614,14 +2614,6 @@ tests:
       enable:
       - observers-resource-watch
     workflow: baremetalds-e2e-upgrade-ovn-ipv6-runc
-- as: e2e-rosa-sts-ovn
-  cron: '@daily'
-  steps:
-    cluster_profile: rosa-e2e-01
-    observers:
-      enable:
-      - observers-resource-watch
-    workflow: rosa-aws-sts-conformance
 - as: e2e-osd-ccs-gcp
   cluster: build10
   cron: '@daily'

--- a/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__nightly-5.0.yaml
@@ -2806,14 +2806,6 @@ tests:
       enable:
       - observers-resource-watch
     workflow: rosa-aws-hcp-conformance
-- as: e2e-rosa-sts-ovn
-  cron: '@daily'
-  steps:
-    cluster_profile: rosa-e2e-03
-    observers:
-      enable:
-      - observers-resource-watch
-    workflow: rosa-aws-sts-conformance
 - as: e2e-osd-ccs-gcp
   cluster: build10
   cron: '@daily'

--- a/core-services/release-controller/_releases/priv/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-5.0.json
@@ -600,14 +600,6 @@
                 "name": "periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-5.0-nightly-x86-payload-control-plane-6nodes-priv"
             }
         },
-        "rosa-classic-sts-conformance": {
-            "disabled": true,
-            "maxRetries": 1,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-5.0-e2e-rosa-sts-ovn-priv"
-            }
-        },
         "telco5g": {
             "disabled": true,
             "optional": true,

--- a/core-services/release-controller/_releases/release-ocp-5.0.json
+++ b/core-services/release-controller/_releases/release-ocp-5.0.json
@@ -551,13 +551,6 @@
         "name": "periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-5.0-nightly-x86-payload-control-plane-6nodes"
       }
     },
-    "rosa-classic-sts-conformance": {
-      "optional": true,
-      "maxRetries": 1,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-5.0-e2e-rosa-sts-ovn"
-      }
-    },
     "telco5g": {
       "optional": true,
       "prowJob": {


### PR DESCRIPTION
## Summary

ROSA Classic STS is not available on 4.23 (not a ROSA version) or 5.0 (HCP-only). Remove `e2e-rosa-sts-ovn` from both nightly configs.

Related: https://github.com/openshift/release/pull/79133

## Changes

- Remove `e2e-rosa-sts-ovn` test from `openshift-release-main__nightly-4.23.yaml`
- Remove `e2e-rosa-sts-ovn` test from `openshift-release-main__nightly-5.0.yaml`
- Regenerated Prow jobs via `make jobs` and `make update`

## Test plan

- [x] `make jobs` passes
- [x] `make update` passes
- [ ] pj-rehearse validates no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates OpenShift CI configuration (openshift/release) to stop scheduling the ROSA Classic STS conformance job where ROSA Classic STS is not supported. The periodic/nightly test e2e-rosa-sts-ovn was removed from nightly configurations for 4.23 and 5.0, and corresponding release-controller verify entries for 5.0 referencing rosa-classic-sts-conformance were removed to prevent CI validation failures.

## What changed in practice

- CI job definitions: Removed the e2e-rosa-sts-ovn test from ci-operator config for:
  - openshift-release-main__nightly-4.23.yaml
  - openshift-release-main__nightly-5.0.yaml
  These nightly manifests were regenerated (periodics/compiled job outputs updated).

- Release controller config: Removed the verify entry rosa-classic-sts-conformance from:
  - core-services/release-controller/_releases/release-ocp-5.0.json
  - core-services/release-controller/_releases/priv/release-ocp-5.0.json
  (ensures release-controller no longer references the removed Prow job for 5.0)

- Prow job generation: Prow jobs were regenerated using make jobs and make update; compiled job lists in ci-operator/jobs were updated accordingly.

## Impact

- Nightly CI no longer attempts ROSA Classic STS conformance for 4.23 (not a ROSA-enabled release) or 5.0 (HCP-only), avoiding failing or invalid job runs.
- Release-controller validation for 5.0 will not fail due to missing job references.

## Validation

- make jobs — passed
- make update — passed
- pj-rehearse — pending

## Related

- Follows up on: https://github.com/openshift/release/pull/79133
<!-- end of auto-generated comment: release notes by coderabbit.ai -->