### PR TITLE
ARO-HCP: Switch prow to centralus

### DIFF
--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -487,8 +487,8 @@ tests:
   steps:
     env:
       ARO_HCP_CLOUD: dev
-      ARO_HCP_DEPLOY_ENV: ci01
-      LOCATION: westus3
+      ARO_HCP_DEPLOY_ENV: prow
+      LOCATION: centralus
     leases:
     - count: 1
       env: ENV_QUOTA_LEASED_RESOURCE

--- a/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
+++ b/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main.yaml
@@ -487,7 +487,7 @@ tests:
   steps:
     env:
       ARO_HCP_CLOUD: dev
-      ARO_HCP_DEPLOY_ENV: prow
+      ARO_HCP_DEPLOY_ENV: ci01
       LOCATION: westus3
     leases:
     - count: 1

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
@@ -76,7 +76,14 @@ yq eval -n "
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.miMockCertName = \"${MSI_MOCK_CERT_NAME}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.registry = \"${HCP_RECOVERY_SOURCE_REGISTRY}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.repository = \"${HCP_RECOVERY_REPOSITORY}\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.digest = \"${HCP_RECOVERY_DIGEST}\"
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.digest = \"${HCP_RECOVERY_DIGEST}\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.systemAgentPool.vmSize = \"Standard_D4ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.userAgentPool.vmSize = \"Standard_D8ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.userAgentPool.name = \"u8adsv6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.infraAgentPool.vmSize = \"Standard_D4ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.systemAgentPool.vmSize = \"Standard_D4ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.userAgentPool.vmSize = \"Standard_D16ads_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.infraAgentPool.vmSize = \"Standard_D4ads_v6\"
 " > "${OVERRIDE_CONFIG_FILE}"
 echo "Created override config at: ${OVERRIDE_CONFIG_FILE}"
 cat "${OVERRIDE_CONFIG_FILE}"

--- a/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
+++ b/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh
@@ -77,13 +77,12 @@ yq eval -n "
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.registry = \"${HCP_RECOVERY_SOURCE_REGISTRY}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.repository = \"${HCP_RECOVERY_REPOSITORY}\" |
   .clouds.dev.environments.${DEPLOY_ENV}.defaults.hcpRecovery.image.digest = \"${HCP_RECOVERY_DIGEST}\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.systemAgentPool.vmSize = \"Standard_D4ads_v6\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.userAgentPool.vmSize = \"Standard_D8ads_v6\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.userAgentPool.name = \"u8adsv6\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.infraAgentPool.vmSize = \"Standard_D4ads_v6\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.systemAgentPool.vmSize = \"Standard_D4ads_v6\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.userAgentPool.vmSize = \"Standard_D16ads_v6\" |
-  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.infraAgentPool.vmSize = \"Standard_D4ads_v6\"
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.systemAgentPool.vmSize = \"Standard_D4ds_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.userAgentPool.vmSize = \"Standard_D8ds_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.svc.aks.infraAgentPool.vmSize = \"Standard_D4ds_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.systemAgentPool.vmSize = \"Standard_D4ds_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.userAgentPool.vmSize = \"Standard_D16ds_v6\" |
+  .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.infraAgentPool.vmSize = \"Standard_D4ds_v6\"
 " > "${OVERRIDE_CONFIG_FILE}"
 echo "Created override config at: ${OVERRIDE_CONFIG_FILE}"
 cat "${OVERRIDE_CONFIG_FILE}"


### PR DESCRIPTION
Circumvent Azure capacity issues switching to a less busy region. The SKU override is required as the prow environment currently configures `Standard_D*ds_v5` and the available quota in Central US is for `Standard_D*ds_v6`. Once this merges we can safely sync prow's config and remove this override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR updates the Azure Red Hat OpenShift Hosted Control Plane (ARO-HCP) Prow CI infrastructure to use the Central US Azure region instead of West US 3 to alleviate Azure capacity constraints.

### CI Job Configuration
The `e2e-parallel` job in the ARO-HCP CI configuration is updated to run in the Central US region by changing the `LOCATION` environment variable from `westus3` to `centralus`.

### VM SKU Overrides
The ARO-HCP provisioning environment script is updated to include VM size overrides for AKS agent pools, specifying `Standard_D*ds_v6` SKU sizes (`Standard_D4ds_v6`, `Standard_D8ds_v6`, and `Standard_D16ds_v6`) across multiple system, user, and infra pools for both service and management clusters. This override is necessary because Central US has quota available for the v6 SKU variant, whereas the standard configuration uses v5 variants. The override is noted as a temporary measure intended to be removed once prow's configuration is synchronized.

## Impact

The changes affect the ARO-HCP project's Prow CI operations, redirecting its e2e-parallel testing pipeline from West US 3 to Central US to resolve Azure capacity constraints while the standard configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->