### PR TITLE
neuron-ci: use stable channel for KServe ROSA cluster provisioning

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
@@ -94,6 +94,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      CHANNEL_GROUP: "stable"
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -114,6 +115,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      CHANNEL_GROUP: "stable"
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
@@ -94,7 +94,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
-      CHANNEL_GROUP: "stable"
+      CHANNEL_GROUP: stable
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -115,7 +115,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
-      CHANNEL_GROUP: "stable"
+      CHANNEL_GROUP: stable
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
@@ -95,7 +95,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
-      CHANNEL_GROUP: "stable"
+      CHANNEL_GROUP: stable
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -116,7 +116,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
-      CHANNEL_GROUP: "stable"
+      CHANNEL_GROUP: stable
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
@@ -95,6 +95,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      CHANNEL_GROUP: "stable"
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -115,6 +116,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      CHANNEL_GROUP: "stable"
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
@@ -95,7 +95,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
-      CHANNEL_GROUP: "stable"
+      CHANNEL_GROUP: stable
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -116,7 +116,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
-      CHANNEL_GROUP: "stable"
+      CHANNEL_GROUP: stable
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml
@@ -95,6 +95,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      CHANNEL_GROUP: "stable"
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0
@@ -115,6 +116,7 @@ tests:
     allow_best_effort_post_steps: true
     cluster_profile: aws-edge-infra
     env:
+      CHANNEL_GROUP: "stable"
       ECO_HWACCEL_NEURON_DEVICE_PLUGIN_IMAGE: public.ecr.aws/neuron/neuron-device-plugin:2.29.94.0
       ECO_HWACCEL_NEURON_DRIVER_VERSION: 2.25.4.0
       ECO_HWACCEL_NEURON_DRIVERS_IMAGE: public.ecr.aws/os-partners/neuron-openshift/neuron-kernel-module:2.25.4.0


### PR DESCRIPTION
## Summary
- Override `CHANNEL_GROUP` from `"candidate,stable"` (default) to `"stable"` for all KServe e2e tests across 4.19, 4.20, and 4.21 stable variants
- The candidate channel has OCP versions with kernels that don't have pre-built Neuron driver images yet, causing KServe weekly jobs to fail (e.g., 4.21 kserve-weekly failed on 2026-05-13 because candidate picked 4.21.13 with kernel `570.111.1` which has no driver image)
- Combined with the existing `OPENSHIFT_VERSION_OFFSET=2`, using the stable channel ensures cluster provisioning picks versions with available driver images

## Test plan
- [ ] Verify CI validation passes (config changes only, no generated file changes needed)
- [ ] Next KServe weekly run should provision from stable channel and find a valid driver image


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates CI operator configs in the rh-ecosystem-edge/neuron-ci repo to force OpenShift cluster provisioning to use the stable release channel for KServe-related ROSA jobs (instead of the default "candidate,stable" behavior). The change ensures ROSA clusters provision an OCP version that has pre-built AWS Neuron driver images available.

## What changed (practical effect)

- For the aws-neuron-operator-kserve-e2e and aws-neuron-operator-kserve-e2e-weekly jobs, the environment variable CHANNEL_GROUP is set to stable so ROSA provisioning will pick releases from the stable stream.
- This prevents the candidate channel from selecting OCP builds whose kernels lack corresponding pre-built Neuron driver images (which caused job failures).

## Files modified

- ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
- ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
- ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.21-stable.yaml

Each file adds CHANNEL_GROUP: stable to the env block for the kserve e2e and kserve e2e weekly test steps.

## Rationale

The candidate channel can select OCP patch releases whose kernels do not have pre-built Neuron driver images (example: 4.21.13 with kernel 570.111.1), causing KServe weekly jobs to fail when the driver image is missing. With the existing OPENSHIFT_VERSION_OFFSET=2 and CHANNEL_GROUP=stable, provisioning consistently selects OCP versions that have available Neuron driver images.

## Additional notes

- A commit removes unnecessary quotes around the CHANNEL_GROUP value to satisfy ci-operator-config-metadata validation (determinize-ci-operator strips quotes).
- Change is config-only; CI validation should be sufficient. Expect CI validation to pass and the next KServe weekly run to provision from the stable channel and find a valid Neuron driver image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->