### PR TITLE
Reverting informing jobs from PR#79034

### DIFF
--- a/core-services/release-controller/_releases/priv/release-ocp-4.22.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.22.json
@@ -11,14 +11,6 @@
     "referenceMode": "source",
     "to": "release-priv",
     "verify": {
-        "agent-ovn-two-node-arbiter-rhcos10-techpreview": {
-            "disabled": true,
-            "maxRetries": 2,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview-priv"
-            }
-        },
         "aggregated-aws-ovn-single-node-upgrade-4.22-micro": {
             "aggregatedProwJob": {
                 "analysisJobCount": 10
@@ -552,22 +544,6 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.22-metal-ovn-single-node-recert-cluster-rename-priv"
-            }
-        },
-        "metal-ovn-two-node-arbiter-private-tests-rhcos10-tp": {
-            "disabled": true,
-            "maxRetries": 2,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp-priv"
-            }
-        },
-        "metal-ovn-two-node-arbiter-rhcos10-techpreview": {
-            "disabled": true,
-            "maxRetries": 2,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview-priv"
             }
         },
         "microshift-ovn-conformance-parallel": {

--- a/core-services/release-controller/_releases/priv/release-ocp-4.23.json
+++ b/core-services/release-controller/_releases/priv/release-ocp-4.23.json
@@ -11,14 +11,6 @@
     "referenceMode": "source",
     "to": "release-priv",
     "verify": {
-        "agent-ovn-two-node-arbiter-rhcos10-techpreview": {
-            "disabled": true,
-            "maxRetries": 2,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview-priv"
-            }
-        },
         "aws-ovn-serial-1of2": {
             "disabled": true,
             "maxRetries": 1,
@@ -139,22 +131,6 @@
             "optional": true,
             "prowJob": {
                 "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ipi-ovn-ipv6-priv"
-            }
-        },
-        "metal-ovn-two-node-arbiter-private-tests-rhcos10-tp": {
-            "disabled": true,
-            "maxRetries": 2,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp-priv"
-            }
-        },
-        "metal-ovn-two-node-arbiter-rhcos10-techpreview": {
-            "disabled": true,
-            "maxRetries": 2,
-            "optional": true,
-            "prowJob": {
-                "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview-priv"
             }
         }
     }

--- a/core-services/release-controller/_releases/release-ocp-4.22.json
+++ b/core-services/release-controller/_releases/release-ocp-4.22.json
@@ -661,27 +661,6 @@
       "prowJob": {
         "name": "periodic-ci-openshift-release-main-nightly-4.22-fips-payload-scan"
       }
-    },
-    "metal-ovn-two-node-arbiter-rhcos10-techpreview": {
-      "optional": true,
-      "maxRetries": 2,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview"
-      }
-    },
-    "agent-ovn-two-node-arbiter-rhcos10-techpreview": {
-      "optional": true,
-      "maxRetries": 2,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview"
-      }
-    },
-    "metal-ovn-two-node-arbiter-private-tests-rhcos10-tp": {
-      "optional": true,
-      "maxRetries": 2,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp"
-      }
     }
   }
 }

--- a/core-services/release-controller/_releases/release-ocp-4.23.json
+++ b/core-services/release-controller/_releases/release-ocp-4.23.json
@@ -63,27 +63,6 @@
       },
       "upgrade": true
     },
-    "metal-ovn-two-node-arbiter-rhcos10-techpreview": {
-      "optional": true,
-      "maxRetries": 2,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-rhcos10-techpreview"
-      }
-    },
-    "agent-ovn-two-node-arbiter-rhcos10-techpreview": {
-      "optional": true,
-      "maxRetries": 2,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-agent-ovn-two-node-arbiter-rhcos10-techpreview"
-      }
-    },
-    "metal-ovn-two-node-arbiter-private-tests-rhcos10-tp": {
-      "optional": true,
-      "maxRetries": 2,
-      "prowJob": {
-        "name": "periodic-ci-openshift-release-main-nightly-4.23-e2e-metal-ovn-two-node-arbiter-private-tests-rhcos10-tp"
-      }
-    },
     "aws-ovn-serial-1of2": {
       "optional": true,
       "maxRetries": 1,


### PR DESCRIPTION
Reverting informing job from https://github.com/openshift/release/pull/79034 as we can just run them as periodic and we do not need them to be informing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR reverts the informing job configurations that were introduced in PR#79034 for OpenShift 4.22 and 4.23 release management. The removed verification jobs—including `agent-ovn-two-node-arbiter-rhcos10-techpreview`, `metal-ovn-two-node-arbiter-rhcos10-techpreview`, and `metal-ovn-two-node-arbiter-private-tests-rhcos10-tp`—will now run as periodic jobs instead of being tied to release verification workflows.

## Changes

Removed OVN two-node arbiter verification job definitions from both public and private release controller configurations:
- **OCP 4.22 public**: Removed 3 verify job entries (~21 lines)
- **OCP 4.22 private**: Removed 3 verify job entries (~24 lines)
- **OCP 4.23 public**: Removed 3 verify job entries (~21 lines)
- **OCP 4.23 private**: Removed 3 verify job entries (~24 lines)

These jobs are no longer needed as release informing jobs since they will run independently on a periodic schedule as part of the OpenShift CI infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->