### PR TITLE
fix use /usr/bin/commenter for rot-issues and stale-issues periodics

### DIFF
--- a/core-services/sanitize-prow-jobs/_config.yaml
+++ b/core-services/sanitize-prow-jobs/_config.yaml
@@ -28369,6 +28369,8 @@ groups:
     - periodic-openshift-release-main-accept-invitations-ci-robot
     - periodic-openshift-release-main-accept-invitations-merge-robot
     - periodic-ci-openshift-release-main-close-issues
+    - periodic-ci-openshift-release-main-rot-issues
+    - periodic-ci-openshift-release-main-stale-issues
     - periodic-openshift-release-main-build12-apply
     - periodic-openshift-release-main-vsphere02-apply
     - pull-ci-openshift-ci-tools-main-secret-bootstrapper-validation
@@ -28407,8 +28409,6 @@ groups:
     - periodic-build09-upgrade
     - periodic-build10-upgrade
     - periodic-build11-upgrade
-    - periodic-ci-openshift-release-main-rot-issues
-    - periodic-ci-openshift-release-main-stale-issues
     - periodic-hosted-mgmt-upgrade
     - periodic-openshift-library-import
     - post-ci-openshift-operator-framework-operator-controller-main-refresh-bumper-pr


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-rot-issues/2054516892621606912

/cc @jmguzik @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Migrates rot-issues and stale-issues periodics to GitHub App authentication

Updates the OpenShift release CI configuration to migrate the `rot-issues` and `stale-issues` periodic jobs to use GitHub App authentication instead of token-based authentication.

These periodic jobs automatically manage the lifecycle of GitHub issues in the openshift/release repository:
- **rot-issues**: Marks issues as rotten after 15 days of inactivity (if already marked as stale)
- **stale-issues**: Marks issues as stale after 30 days of inactivity

Both jobs now use `/usr/bin/commenter` with GitHub App credentials (`--github-app-id` and `--github-app-private-key-path`) for authentication, improving security by removing reliance on personal access tokens.

The configuration changes are contained within `core-services/sanitize-prow-jobs/_config.yaml`, which manages sanitization rules for Prow job definitions in the OpenShift CI infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->