### PR TITLE
Add one-off claude payload agent job for 4.19 nightly

### DIFF
--- a/ci-operator/config/openshift/release/openshift-release-main__claude-payload-4.19-nightly-20260513.yaml
+++ b/ci-operator/config/openshift/release/openshift-release-main__claude-payload-4.19-nightly-20260513.yaml
@@ -1,0 +1,17 @@
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: claude-payload-agent
+  cron: '@yearly'
+  steps:
+    env:
+      PAYLOAD_TAG: 4.19.0-0.nightly-2026-05-13-043200
+    workflow: openshift-claude-payload
+zz_generated_metadata:
+  branch: main
+  org: openshift
+  repo: release
+  variant: claude-payload-4.19-nightly-20260513


### PR DESCRIPTION
## Summary
- Adds a one-off periodic job (`periodic-ci-openshift-release-main-claude-payload-agent-4-19-nightly-20260513`) to analyze payload `4.19.0-0.nightly-2026-05-13-043200`
- Uses the `openshift-claude-payload` workflow with `PAYLOAD_TAG` hardcoded to the target nightly
- Scheduled `@yearly` (will be triggered manually via `pj-rehearse` or `gangway`)

## Test plan
- [ ] Verify pj-rehearse creates and runs the job on PR
- [ ] Remove job after analysis is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a temporary one-off periodic job to the OpenShift release CI infrastructure for analyzing a specific 4.19 nightly payload using Claude. 

The new CI job configuration (`openshift-release-main__claude-payload-4.19-nightly-20260513.yaml`) defines:
- A test job named `claude-payload-agent` that runs the `openshift-claude-payload` workflow
- The `PAYLOAD_TAG` environment variable hardcoded to the target nightly build (`4.19.0-0.nightly-2026-05-13-043200`)
- Resource limits (100m CPU, 200Mi memory) for all containers
- A yearly cron schedule, intended for manual triggering via pj-rehearse or gangway

This is a temporary job configuration that should be removed after the payload analysis is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->