### PR TITLE
OCPBUGS-85546: mirror-images-qe-test-images: add per-image retry logic

### DIFF
--- a/ci-operator/step-registry/mirror-images/qe-test-images/mirror-images-qe-test-images-commands.sh
+++ b/ci-operator/step-registry/mirror-images/qe-test-images/mirror-images-qe-test-images-commands.sh
@@ -134,11 +134,21 @@ then
 fi
 
 # MIRROR IMAGES
- # To avoid 409 too many request error, mirroring image one by one
- for image in `cat /tmp/mirror-images-list.yaml`
- do
-     oc image mirror $image  --insecure=true -a "${new_pull_secret}" \
-         --skip-missing=true --skip-verification=true --keep-manifest-list=true --filter-by-os='.*'
- done
+# To avoid 409 too many request error, mirroring image one by one
+for image in $(cat /tmp/mirror-images-list.yaml)
+do
+    attempts=0
+    max_attempts=3
+    until oc image mirror "$image" --insecure=true -a "${new_pull_secret}" \
+        --skip-missing=true --skip-verification=true --keep-manifest-list=true --filter-by-os='.*'; do
+        attempts=$((attempts + 1))
+        if [ $attempts -ge $max_attempts ]; then
+            echo "Failed to mirror $image after $max_attempts attempts"
+            exit 1
+        fi
+        echo "Mirroring $image attempt $attempts failed, retrying in 30s..."
+        sleep 30
+    done
+done
 
 rm -f "${new_pull_secret}"


### PR DESCRIPTION
The mirror-images-qe-test-images step lacks retry logic, causing chronic failures on disconnected OpenStack singlestackv6 jobs due to transient 'unexpected EOF' errors when uploading large image layers through a proxy to the mirror registry.

Add a per-image retry loop (3 attempts, 30s backoff) matching the pattern already used by mirror-images-by-oc-adm. Also fix minor shell hygiene: quote $image and use $(...) instead of backticks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Mirror images QE test images: Add per-image retry logic

Adds automatic retry logic to the `mirror-images-qe-test-images` CI step to improve reliability when mirroring OpenShift QE test images to disconnected environments.

**What changed:**
The mirror image operation now wraps each image in a retry loop with up to 3 attempts and 30-second backoff between failures. Previously, a single transient error would cause the entire step to fail. This follows the same retry pattern already used by the `mirror-images-by-oc-adm` step.

The script iterates through images sequentially and attempts to mirror each one up to 3 times before giving up. This addresses recurring failures in disconnected OpenStack singlestackv6 jobs caused by transient "unexpected EOF" errors when uploading large image layers through a proxy to the mirror registry.

Also includes minor shell hygiene improvements: proper quoting of the `$image` variable in error messages.

**Impact:**
- Improves stability of QE test image mirroring in disconnected cluster environments
- Reduces failure rate for jobs relying on proxy-based image mirroring
- No changes to the image list or mirroring destinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->