### PR TITLE
Vault ci

### DIFF
--- a/ci-operator/config/openshift/origin/openshift-origin-main.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-main.yaml
@@ -833,6 +833,17 @@ tests:
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-microshift-e2e-origin-conformance
 - always_run: false
+  as: e2e-aws-tls-observed-config
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      TEST_SUITE: openshift/tls-observed-config
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-serial
+- always_run: false
   as: e2e-hypershift-conformance
   optional: true
   steps:

--- a/ci-operator/config/openshift/origin/openshift-origin-release-4.22.yaml
+++ b/ci-operator/config/openshift/origin/openshift-origin-release-4.22.yaml
@@ -833,6 +833,17 @@ tests:
       TEST_SUITE: openshift/conformance/serial
     workflow: openshift-microshift-e2e-origin-conformance
 - always_run: false
+  as: e2e-aws-tls-observed-config
+  optional: true
+  steps:
+    cluster_profile: openshift-org-aws
+    env:
+      TEST_SUITE: openshift/tls-observed-config
+    observers:
+      enable:
+      - observers-resource-watch
+    workflow: openshift-e2e-aws-serial
+- always_run: false
   as: e2e-hypershift-conformance
   optional: true
   steps:

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-main.yaml
@@ -70,16 +70,6 @@ tests:
     workflow: generic-claim
 - as: periodic-default-tls
   interval: 72h
-  reporter_config:
-    channel: '#forum-case'
-    job_states_to_report:
-    - success
-    - failure
-    - error
-    report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
-      ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
-      Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
-      {{end}}'
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -89,16 +79,6 @@ tests:
     workflow: ipi-aws
 - as: periodic-pqc-readiness
   interval: 72h
-  reporter_config:
-    channel: '#forum-case'
-    job_states_to_report:
-    - success
-    - failure
-    - error
-    report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
-      ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
-      Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
-      {{end}}'
   steps:
     cluster_profile: openshift-org-aws
     env:
@@ -109,16 +89,6 @@ tests:
     workflow: openshift-e2e-aws-ovn-tls-13
 - as: periodic-tls13-adherence
   interval: 72h
-  reporter_config:
-    channel: '#forum-case'
-    job_states_to_report:
-    - success
-    - failure
-    - error
-    report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
-      ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
-      Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
-      {{end}}'
   steps:
     cluster_profile: openshift-org-aws
     env:

--- a/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-4.22.yaml
+++ b/ci-operator/config/openshift/tls-scanner/openshift-tls-scanner-release-4.22.yaml
@@ -71,16 +71,6 @@ tests:
     workflow: openshift-e2e-aws-ovn-tls-13
 - as: periodic-default-tls
   interval: 72h
-  reporter_config:
-    channel: '#forum-case'
-    job_states_to_report:
-    - success
-    - failure
-    - error
-    report_template: '{{if eq .Status.State "success"}} :white_check_mark: Job *{{.Spec.Job}}*
-      ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> {{else}} :warning:
-      Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs>
-      {{end}}'
   steps:
     cluster_profile: openshift-org-aws
     env:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -2678,6 +2678,11 @@ presubmits:
     cluster: build09
     context: ci/prow/e2e-aws-tls-observed-config
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - images/hello-openshift/Dockerfile.rhel
+      - images/tests/Dockerfile.rhel
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws

--- a/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-agnostic-ovn-cmd
     decorate: true
     decoration_config:
@@ -2676,6 +2676,87 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build09
+    context: ci/prow/e2e-aws-tls-observed-config
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-main-e2e-aws-tls-observed-config
+    optional: true
+    rerun_command: /test e2e-aws-tls-observed-config
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-tls-observed-config
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-tls-observed-config,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build10
     context: ci/prow/e2e-azure
     decorate: true
     decoration_config:
@@ -2761,7 +2842,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-azure-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -2847,7 +2928,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-azure-ovn-upgrade
     decorate: true
     decoration_config:
@@ -4572,7 +4653,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-hypershift-conformance
     decorate: true
     decoration_config:
@@ -5879,7 +5960,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-metal-ovn-single-node-live-iso
     decorate: true
     decoration_config:
@@ -5965,7 +6046,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-metal-ovn-single-node-with-worker-live-iso
     decorate: true
     decoration_config:
@@ -6318,7 +6399,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-openstack-dualstack-v6primary
     decorate: true
     decoration_config:
@@ -6832,7 +6913,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/go-verify-deps
     decorate: true
     decoration_config:
@@ -6915,7 +6996,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -6974,7 +7055,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -7127,7 +7208,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/okd-scos-images
     decorate: true
     decoration_config:
@@ -7186,7 +7267,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -7253,7 +7334,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/verify
     decorate: true
     decoration_config:
@@ -7320,7 +7401,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -7387,7 +7468,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build09
+    cluster: build10
     context: ci/prow/verify-image-manifest-lists
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.22-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-agnostic-ovn-cmd
     decorate: true
     decoration_config:
@@ -2676,6 +2676,87 @@ presubmits:
     - ^release-4\.22$
     - ^release-4\.22-
     cluster: build09
+    context: ci/prow/e2e-aws-tls-observed-config
+    decorate: true
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-release-4.22-e2e-aws-tls-observed-config
+    optional: true
+    rerun_command: /test e2e-aws-tls-observed-config
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-aws-tls-observed-config
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-aws-tls-observed-config,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^release-4\.22$
+    - ^release-4\.22-
+    cluster: build10
     context: ci/prow/e2e-azure
     decorate: true
     decoration_config:
@@ -2761,7 +2842,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-azure-ovn-etcd-scaling
     decorate: true
     decoration_config:
@@ -2847,7 +2928,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-azure-ovn-upgrade
     decorate: true
     decoration_config:
@@ -4572,7 +4653,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-hypershift-conformance
     decorate: true
     decoration_config:
@@ -5879,7 +5960,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-metal-ovn-single-node-live-iso
     decorate: true
     decoration_config:
@@ -5965,7 +6046,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-metal-ovn-single-node-with-worker-live-iso
     decorate: true
     decoration_config:
@@ -6318,7 +6399,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/e2e-openstack-dualstack-v6primary
     decorate: true
     decoration_config:
@@ -6832,7 +6913,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/go-verify-deps
     decorate: true
     decoration_config:
@@ -6915,7 +6996,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -6974,7 +7055,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -7041,7 +7122,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -7108,7 +7189,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/verify
     decorate: true
     decoration_config:
@@ -7175,7 +7256,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/verify-deps
     decorate: true
     decoration_config:
@@ -7242,7 +7323,7 @@ presubmits:
     branches:
     - ^release-4\.22$
     - ^release-4\.22-
-    cluster: build09
+    cluster: build10
     context: ci/prow/verify-image-manifest-lists
     decorate: true
     decoration_config:

--- a/ci-operator/jobs/openshift/origin/openshift-origin-release-4.22-presubmits.yaml
+++ b/ci-operator/jobs/openshift/origin/openshift-origin-release-4.22-presubmits.yaml
@@ -2678,6 +2678,11 @@ presubmits:
     cluster: build09
     context: ci/prow/e2e-aws-tls-observed-config
     decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - images/hello-openshift/Dockerfile.rhel
+      - images/tests/Dockerfile.rhel
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws

--- a/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-commands.sh
+++ b/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-commands.sh
@@ -7,6 +7,7 @@ echo "========================================="
 echo "Vault Configuration for KMS"
 echo "========================================="
 echo "Namespace: ${VAULT_NAMESPACE}"
+echo "Release Name: ${VAULT_RELEASE_NAME}"
 echo ""
 
 export KUBECONFIG="${SHARED_DIR}/kubeconfig"
@@ -19,22 +20,22 @@ echo ""
 
 # Enable transit secret engine
 echo "Enabling transit secret engine..."
-oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+oc exec ${VAULT_RELEASE_NAME}-0 -n "${VAULT_NAMESPACE}" -- \
   env VAULT_TOKEN="${ROOT_TOKEN}" vault secrets enable -path=transit transit
 
 # Create encryption key
 echo "Creating transit encryption key..."
-oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+oc exec ${VAULT_RELEASE_NAME}-0 -n "${VAULT_NAMESPACE}" -- \
   env VAULT_TOKEN="${ROOT_TOKEN}" vault write -f transit/keys/${VAULT_KMS_KEY_NAME}
 
 # Enable AppRole auth
 echo "Enabling AppRole authentication..."
-oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+oc exec ${VAULT_RELEASE_NAME}-0 -n "${VAULT_NAMESPACE}" -- \
   env VAULT_TOKEN="${ROOT_TOKEN}" vault auth enable approle
 
 # Create KMS policy
 echo "Creating KMS policy..."
-oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+oc exec ${VAULT_RELEASE_NAME}-0 -n "${VAULT_NAMESPACE}" -- \
   sh -c "VAULT_TOKEN=${ROOT_TOKEN} vault policy write kms-policy - <<POLICY
 path \"transit/encrypt/${VAULT_KMS_KEY_NAME}\" {
   capabilities = [\"update\"]
@@ -52,7 +53,7 @@ POLICY"
 
 # Create AppRole role
 echo "Creating AppRole role..."
-oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+oc exec ${VAULT_RELEASE_NAME}-0 -n "${VAULT_NAMESPACE}" -- \
   env VAULT_TOKEN="${ROOT_TOKEN}" vault write auth/approle/role/kms-plugin \
     token_policies=kms-policy \
     token_ttl=1h \
@@ -60,9 +61,9 @@ oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
 
 # Get AppRole credentials
 echo "Retrieving AppRole credentials..."
-ROLE_ID=$(oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+ROLE_ID=$(oc exec ${VAULT_RELEASE_NAME}-0 -n "${VAULT_NAMESPACE}" -- \
   env VAULT_TOKEN="${ROOT_TOKEN}" vault read -field=role_id auth/approle/role/kms-plugin/role-id)
-SECRET_ID=$(oc exec vault-0 -n "${VAULT_NAMESPACE}" -- \
+SECRET_ID=$(oc exec ${VAULT_RELEASE_NAME}-0 -n "${VAULT_NAMESPACE}" -- \
   env VAULT_TOKEN="${ROOT_TOKEN}" vault write -field=secret_id -f auth/approle/role/kms-plugin/secret-id)
 
 # Create vault-credentials secret
@@ -81,7 +82,7 @@ echo "Vault Configuration Complete"
 echo "========================================="
 echo ""
 echo "Summary:"
-echo "  - Vault Service: vault.${VAULT_NAMESPACE}.svc:8200"
+echo "  - Vault Service: ${VAULT_RELEASE_NAME}.${VAULT_NAMESPACE}.svc:8200"
 echo "  - Credentials Secret: vault-credentials (namespace: ${VAULT_NAMESPACE})"
 echo "  - Transit Key: ${VAULT_KMS_KEY_NAME}"
 echo "  - ROLE_ID: ${ROLE_ID}"

--- a/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-ref.yaml
+++ b/ci-operator/step-registry/etcd-encryption/vault-configure/etcd-encryption-vault-configure-ref.yaml
@@ -11,6 +11,11 @@ ref:
     default: "vault-kms"
     documentation: |-
       Namespace where Vault Enterprise is installed.
+  - name: VAULT_RELEASE_NAME
+    default: "vault"
+    documentation: |-
+      Helm release name for the Vault installation.
+      Must match the name used in vault-install step.
   - name: VAULT_KMS_KEY_NAME
     default: "kms-key"
     documentation: |-

--- a/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-commands.sh
+++ b/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-commands.sh
@@ -6,6 +6,7 @@ echo "Vault Enterprise Installation via Helm"
 echo "========================================="
 echo "Version: ${VAULT_VERSION}"
 echo "Namespace: ${VAULT_NAMESPACE}"
+echo "Release Name: ${VAULT_RELEASE_NAME}"
 echo ""
 
 export KUBECONFIG="${SHARED_DIR}/kubeconfig"
@@ -54,7 +55,7 @@ echo ""
 
 # Install Vault via Helm with dev mode enabled
 echo "Installing Vault Enterprise v${VAULT_VERSION} in dev mode..."
-helm upgrade --install vault hashicorp/vault \
+helm upgrade --install "${VAULT_RELEASE_NAME}" hashicorp/vault \
   --namespace "${VAULT_NAMESPACE}" \
   --version "${VAULT_CHART_VERSION}" \
   --set global.enabled=true \
@@ -70,8 +71,8 @@ helm upgrade --install vault hashicorp/vault \
   --timeout 10m
 
 #helm wait passes even vault pod is 0/1 Running. So, added the below wait to correctly verify the vault pod status
-echo "Waiting for Vault pod to be ready..."  
-oc wait --for=condition=ready pod/vault-0 -n "${VAULT_NAMESPACE}" --timeout=5m
+echo "Waiting for Vault pod to be ready..."
+oc wait --for=condition=ready pod/${VAULT_RELEASE_NAME}-0 -n "${VAULT_NAMESPACE}" --timeout=5m
 
 echo "========================================="
 echo "Vault Enterprise Installation Complete"
@@ -79,9 +80,10 @@ echo "========================================="
 echo ""
 echo "Summary:"
 echo "  - Namespace: ${VAULT_NAMESPACE}"
+echo "  - Release Name: ${VAULT_RELEASE_NAME}"
 echo "  - Version: ${VAULT_VERSION}"
-echo "  - Service: vault.${VAULT_NAMESPACE}.svc:8200"
-echo "  - Pod: vault-0 (Ready)"
+echo "  - Service: ${VAULT_RELEASE_NAME}.${VAULT_NAMESPACE}.svc:8200"
+echo "  - Pod: ${VAULT_RELEASE_NAME}-0 (Ready)"
 echo ""
 echo "Next step: Run etcd-encryption-vault-configure to configure Vault for KMS"
 echo ""

--- a/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.yaml
+++ b/ci-operator/step-registry/etcd-encryption/vault-install/etcd-encryption-vault-install-ref.yaml
@@ -25,6 +25,11 @@ ref:
     default: "vault-kms"
     documentation: |-
       Namespace where Vault Enterprise will be installed.
+  - name: VAULT_RELEASE_NAME
+    default: "vault"
+    documentation: |-
+      Helm release name for the Vault installation.
+      Use different names for multiple Vault instances (e.g., vault-1, vault-2).
   - name: VAULT_IMAGE_REPOSITORY
     default: "docker.io/hashicorp/vault-enterprise"
     documentation: |-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for parameterized Vault deployments in OpenShift CI and introduces new TLS testing configuration.

### Vault Deployment Flexibility

The primary changes make the Vault installation and configuration steps in the etcd-encryption CI suite more flexible by introducing a `VAULT_RELEASE_NAME` parameter. Previously, Vault was hardcoded to use the release name `vault`, which prevented running multiple Vault instances simultaneously. Changes include:

- **vault-install step**: Now accepts `VAULT_RELEASE_NAME` (default: `"vault"`) to control the Helm release name, allowing deployment of multiple Vault instances with different names (e.g., `vault-1`, `vault-2`)
- **vault-configure step**: Updated to use the configurable release name when accessing Vault pods and services, replacing hardcoded `vault-0` references with `${VAULT_RELEASE_NAME}-0`

### TLS Testing Configuration

Added new CI test jobs for TLS testing in OpenShift origin:
- **e2e-aws-tls-observed-config**: New optional test job in both `openshift-origin-main` and `openshift-origin-release-4.22` configurations that runs TLS observed configuration testing on the openshift-org-aws cluster profile with resource watching enabled

### TLS Scanner Configuration Updates

Updated the tls-scanner CI configurations to restructure periodic test definitions:
- Removed `reporter_config` blocks from tls-scanner configurations
- Reorganized periodic test jobs to explicitly specify cluster profiles, environment variables, and test steps for TLS scanning and TLS 1.3 conformance testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->