### PR TITLE
Configs to build and promote the vcf-migration-operator image

### DIFF
--- a/ci-operator/config/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main.yaml
+++ b/ci-operator/config/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main.yaml
@@ -4,6 +4,10 @@ images:
   items:
   - dockerfile_path: Dockerfile
     to: vcf-migration-operator
+promotion:
+  to:
+  - namespace: vcf
+    tag: latest
 releases:
   latest:
     candidate:

--- a/ci-operator/jobs/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/vcf-migration-operator/openshift-vcf-migration-operator-main-postsubmits.yaml
@@ -1,0 +1,65 @@
+postsubmits:
+  openshift/vcf-migration-operator:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    cluster: build01
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci.openshift.io/generator: prowgen
+      job-release: "5.0"
+    max_concurrency: 1
+    name: branch-ci-openshift-vcf-migration-operator-main-images
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
+        - --promote
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/push-secret
+          name: push-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: push-secret
+        secret:
+          secretName: registry-push-credentials-ci-central
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator


### PR DESCRIPTION
Promotes ci/vcf-migration-operator:latest as base_image for other repositories to reference in their CI configurations the latest release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds CI configuration for the openshift/vcf-migration-operator repository so the operator image is built, tested, and promoted for other repos to reference as a base image.

Practical effects:
- Enables building the vcf-migration-operator image from the repository (build_root.from_repository: true; Dockerfile at Dockerfile → image name: vcf-migration-operator).
- Runs unit tests in CI (tests: as: unit → commands: make test; container from: src).
- Configures image promotion to the OpenShift CI registry under the vcf namespace with tag latest (promotion.to: namespace: vcf, tag: latest), making the image available for other repos’ CI.
- Declares a release candidate stream for version 5.0 on the nightly stream (releases.latest.candidate: product: ocp, stream: nightly, version: "5.0").
- Sets resource requests/limits for CI runs (requests: cpu 100m, memory 200Mi; limits: memory 4Gi).

Overall, this makes the vcf-migration-operator image available as a promoted base image for CI workflows targeting the 5.0 nightly candidate stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->