### PR TITLE
update oas and auth with vault setup chain

### DIFF
--- a/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master.yaml
+++ b/ci-operator/config/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master.yaml
@@ -3,6 +3,10 @@ base_images:
     name: test
     namespace: ocp-kni
     tag: dev-scripts
+  vault_kube_kms:
+    name: vault-kube-kms
+    namespace: control-plane_vault
+    tag: 0.0.1
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   from_repository: true
@@ -304,11 +308,14 @@ tests:
 - always_run: false
   as: e2e-aws-operator-encryption-kms-ote
   optional: true
+  run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
   steps:
     cluster_profile: openshift-org-aws
     env:
+      FEATURE_SET: TechPreviewNoUpgrade
       TEST_SUITE: openshift/cluster-authentication-operator/encryption-kms
     test:
+    - chain: etcd-encryption-vault-setup
     - ref: openshift-e2e-test
     workflow: ipi-aws
   timeout: 4h0m0s

--- a/ci-operator/config/openshift/cluster-openshift-apiserver-operator/openshift-cluster-openshift-apiserver-operator-main.yaml
+++ b/ci-operator/config/openshift/cluster-openshift-apiserver-operator/openshift-cluster-openshift-apiserver-operator-main.yaml
@@ -1,3 +1,8 @@
+base_images:
+  vault_kube_kms:
+    name: vault-kube-kms
+    namespace: control-plane_vault
+    tag: 0.0.1
 binary_build_commands: make build --warn-undefined-variables
 build_root:
   from_repository: true
@@ -133,6 +138,7 @@ tests:
     env:
       FEATURE_SET: TechPreviewNoUpgrade
     test:
+    - chain: etcd-encryption-vault-setup
     - as: test
       cli: latest
       commands: |
@@ -142,6 +148,19 @@ tests:
         requests:
           cpu: 100m
       timeout: 4h0m0s
+    workflow: ipi-gcp
+- always_run: false
+  as: e2e-gcp-operator-encryption-kms-ote
+  optional: true
+  run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
+  steps:
+    cluster_profile: openshift-org-gcp
+    env:
+      FEATURE_SET: TechPreviewNoUpgrade
+      TEST_SUITE: openshift/cluster-openshift-apiserver-operator/encryption-kms
+    test:
+    - chain: etcd-encryption-vault-setup
+    - ref: openshift-e2e-test
     workflow: ipi-gcp
 - as: verify-deps
   steps:

--- a/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-authentication-operator/openshift-cluster-authentication-operator-master-presubmits.yaml
@@ -447,6 +447,7 @@ presubmits:
     name: pull-ci-openshift-cluster-authentication-operator-master-e2e-aws-operator-encryption-kms-ote
     optional: true
     rerun_command: /test e2e-aws-operator-encryption-kms-ote
+    run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
     spec:
       containers:
       - args:

--- a/ci-operator/jobs/openshift/cluster-openshift-apiserver-operator/openshift-cluster-openshift-apiserver-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/cluster-openshift-apiserver-operator/openshift-cluster-openshift-apiserver-operator-main-presubmits.yaml
@@ -432,6 +432,92 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build08
+    context: ci/prow/e2e-gcp-operator-encryption-kms-ote
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - .ci-operator.yaml
+      - Dockerfile
+    labels:
+      ci-operator.openshift.io/cloud: gcp
+      ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-cluster-openshift-apiserver-operator-main-e2e-gcp-operator-encryption-kms-ote
+    optional: true
+    rerun_command: /test e2e-gcp-operator-encryption-kms-ote
+    run_if_changed: ^(vendor/github.com/openshift/library-go/pkg/operator/encryption)|^(test/e2e-encryption-kms)|^(test/library/encryption)
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-gcp-operator-encryption-kms-ote
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-gcp-operator-encryption-kms-ote,?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build08
     context: ci/prow/e2e-gcp-operator-encryption-rotation-aescbc
     decorate: true
     decoration_config:


### PR DESCRIPTION
update the ci-operator config of  oas-o and auth-o with the vault-setup chain.  
Please refer this for more details.
https://redhat-internal.slack.com/archives/C0A0DMK3N7K/p1778488432410269?thread_ts=1778485365.758369&cid=C0A0DMK3N7K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR updates the CI configuration for two OpenShift core component repositories—Cluster Authentication Operator and Cluster OpenShift API Server Operator—to integrate the vault-setup chain for encryption testing.

## Changes

**Cluster Authentication Operator** (`openshift-cluster-authentication-operator-master.yaml`)
- Added a base image reference for `vault_kube_kms` (tag 0.0.1) in the `dev-scripts` image
- Enhanced the `e2e-aws-operator-encryption-kms-ote` test job with:
  - Trigger condition for encryption/KMS-related path changes
  - `etcd-encryption-vault-setup` chain integration into the test steps
  - `TechPreviewNoUpgrade` feature set configuration

**Cluster OpenShift API Server Operator** (`openshift-cluster-openshift-apiserver-operator-main.yaml`)
- Added base image configuration for `vault_kube_kms` 
- Updated the GCP KMS encryption E2E job to include the `etcd-encryption-vault-setup` chain
- Introduced a new optional GCP test job (`e2e-gcp-operator-encryption-kms-ote`) configured for vault-based encryption testing with `TechPreviewNoUpgrade` feature set

## Impact
These changes enable both operators' CI pipelines to validate encryption functionality using the new vault-setup chain, ensuring that KMS and etcd encryption features work correctly with vault-based key management during development and integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->