### PR TITLE
OCM-24865 | fix: Add masking to prevent logs from being redacted in prow

### DIFF
--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml
@@ -33,7 +33,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -45,7 +48,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -70,7 +73,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -82,7 +88,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -107,7 +113,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -119,7 +128,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -224,7 +233,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -236,7 +248,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \

--- a/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
+++ b/ci-operator/config/openshift-online/rosa-e2e/openshift-online-rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml
@@ -33,7 +33,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export AWS_SHARED_VPC_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -45,7 +48,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -70,7 +73,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -82,7 +88,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -107,7 +113,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -119,7 +128,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -144,7 +153,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -156,7 +168,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -181,7 +193,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -193,7 +208,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -218,7 +233,10 @@ tests:
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
 
-    env -i bash --norc --noprofile << EOF > /tmp/podman.env
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
@@ -230,7 +248,7 @@ tests:
 
     podman run \
     --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-    --env-file /tmp/podman.env \
+    --env-file "${podman_env_file}" \
     -v /usr/local/cs-qe-credentials:/credentials:ro,z \
     --rm \
     quay.io/redhat-services-prod/ocmci/ocmci:latest \
@@ -374,10 +392,15 @@ tests:
     else
       JOB_LINK="${JOB_LINK}logs/${JOB_NAME}/${BUILD_ID}"
     fi
-    env -i bash --norc --noprofile <<'EOF' > /tmp/podman.env
+
+    podman_env_file="$(mktemp /tmp/podman.env.XXXXXX)"
+    trap 'rm -f "${podman_env_file}"' EXIT
+    umask 077
+    env -i bash --norc --noprofile << EOF > "${podman_env_file}"
     export AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-cred
     export SHARED_VPC_AWS_SHARED_CREDENTIALS_FILE=/credentials/aws-shared-vpc-credentials
     export ENABLE_JIRA_REPORTING=true
+    export JOB_LINK="${JOB_LINK}"
     source /usr/local/cs-qe-credentials/ocm-tokens
     source /usr/local/cs-qe-credentials/jira-cred
     env | grep -v '^_='
@@ -385,7 +408,7 @@ tests:
 
     podman run \
       --authfile /usr/local/cs-qe-credentials/.dockerconfigjson \
-      --env-file /tmp/podman.env \
+      --env-file "${podman_env_file}" \
       -v /usr/local/cs-qe-credentials:/credentials:ro,z \
       --rm \
       quay.io/redhat-services-prod/ocmci/ocmci:latest \


### PR DESCRIPTION
Certain logs are being redacted from Prow runs, adding masking protection to all the generated env files to prevent removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This change addresses log redaction issues in Prow by modifying how environment files are handled in ROSA E2E test job configurations. Instead of using a fixed `/tmp/podman.env` file that could be subject to redaction, the test jobs now generate temporary environment files with restricted permissions.

## Changes

The PR updates two ROSA E2E test configuration files to implement protected environment file handling:

**rosa-e2e-main__ocm-fvt-rosa-classic-staging.yaml** and **rosa-e2e-main__ocm-fvt-rosa-hcp-staging.yaml**

Each affected job's test command now:
- Creates a unique temporary file using `mktemp /tmp/podman.env.XXXXXX` instead of writing to a static path
- Restricts file permissions with `umask 077` to prevent unauthorized access
- Ensures cleanup using a `trap` on `EXIT`
- Uses the temporary file path in the `podman run --env-file` invocation

This approach ensures that environment variables used in the test execution are masked from Prow's redaction mechanisms, preventing sensitive logs from being inadvertently stripped during test output processing.

## Impact

The changes affect multiple ROSA E2E test variants (classic staging, HCP staging with various configurations including AD, shared VPC, Adobe, zero-egress, and upgrade variants). All updates maintain the same functional behavior while protecting against log redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->