### PR TITLE
MCO-2257: use RHEL10 by default in 5.0

### DIFF
--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml
@@ -43,7 +43,7 @@ build_root:
   from_repository: true
 images:
   items:
-  - dockerfile_path: Dockerfile.rhel7
+  - dockerfile_path: Dockerfile.rhel10
     to: machine-config-operator
   - dockerfile_literal: |
       FROM registry.ci.openshift.org/ocp/4.13:rhel-coreos

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main__okd-scos.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main__okd-scos.yaml
@@ -13,7 +13,7 @@ images:
   - build_args:
     - name: TAGS
       value: scos
-    dockerfile_path: Dockerfile.rhel7
+    dockerfile_path: Dockerfile.rhel10
     from: origin_scos-4.22_base-stream9
     to: machine-config-operator
 promotion:

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23.yaml
@@ -43,7 +43,7 @@ build_root:
   from_repository: true
 images:
   items:
-  - dockerfile_path: Dockerfile.rhel7
+  - dockerfile_path: Dockerfile.rhel9
     to: machine-config-operator
   - dockerfile_literal: |
       FROM registry.ci.openshift.org/ocp/4.13:rhel-coreos

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__arm64-periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__arm64-periodics.yaml
@@ -15,7 +15,7 @@ build_root:
   from_repository: true
 images:
   items:
-  - dockerfile_path: Dockerfile.rhel7
+  - dockerfile_path: Dockerfile.rhel9
     to: machine-config-operator
 releases:
   latest:

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23__periodics.yaml
@@ -15,7 +15,7 @@ build_root:
   from_repository: true
 images:
   items:
-  - dockerfile_path: Dockerfile.rhel7
+  - dockerfile_path: Dockerfile.rhel9
     to: machine-config-operator
 releases:
   initial:

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0.yaml
@@ -43,7 +43,7 @@ build_root:
   from_repository: true
 images:
   items:
-  - dockerfile_path: Dockerfile.rhel7
+  - dockerfile_path: Dockerfile.rhel10
     to: machine-config-operator
   - dockerfile_literal: |
       FROM registry.ci.openshift.org/ocp/4.13:rhel-coreos

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__arm64-periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__arm64-periodics.yaml
@@ -15,7 +15,7 @@ build_root:
   from_repository: true
 images:
   items:
-  - dockerfile_path: Dockerfile.rhel7
+  - dockerfile_path: Dockerfile.rhel10
     to: machine-config-operator
 releases:
   latest:

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0__periodics.yaml
@@ -15,7 +15,7 @@ build_root:
   from_repository: true
 images:
   items:
-  - dockerfile_path: Dockerfile.rhel7
+  - dockerfile_path: Dockerfile.rhel10
     to: machine-config-operator
 releases:
   initial:

--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.1.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-release-5.1.yaml
@@ -43,7 +43,7 @@ build_root:
   from_repository: true
 images:
   items:
-  - dockerfile_path: Dockerfile.rhel7
+  - dockerfile_path: Dockerfile.rhel10
     to: machine-config-operator
   - dockerfile_literal: |
       FROM registry.ci.openshift.org/ocp/4.13:rhel-coreos

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-main-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-main-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
@@ -70,7 +70,7 @@ postsubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: okd-scos

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-main-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -77,7 +77,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -163,7 +163,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -249,7 +249,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -334,7 +334,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -429,7 +429,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -513,7 +513,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -598,7 +598,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -683,7 +683,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -768,7 +768,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -855,7 +855,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -939,7 +939,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1024,7 +1024,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1109,7 +1109,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1194,7 +1194,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1279,7 +1279,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1364,7 +1364,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1449,7 +1449,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1534,7 +1534,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1619,7 +1619,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1704,7 +1704,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1789,7 +1789,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -1874,7 +1874,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -1959,7 +1959,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2044,7 +2044,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2129,7 +2129,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2214,7 +2214,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2307,7 +2307,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2394,7 +2394,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2480,7 +2480,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2566,7 +2566,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2652,7 +2652,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
       timeout: 4h0m0s
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -2739,7 +2739,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2823,7 +2823,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2908,7 +2908,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2993,7 +2993,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3078,7 +3078,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3163,7 +3163,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3248,7 +3248,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3335,7 +3335,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -3419,7 +3419,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -3504,7 +3504,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: packet-edge
@@ -3590,7 +3590,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3676,7 +3676,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3762,7 +3762,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: equinix-edge-enablement
       ci-operator.openshift.io/cloud-cluster-profile: equinix-edge-enablement
@@ -3847,7 +3847,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: equinix-edge-enablement
       ci-operator.openshift.io/cloud-cluster-profile: equinix-edge-enablement
@@ -3932,7 +3932,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
@@ -4018,7 +4018,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-hwoffload
       ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
@@ -4103,7 +4103,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vh-mecha-central
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
@@ -4188,7 +4188,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -4273,7 +4273,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
@@ -4358,7 +4358,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-hwoffload
       ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
@@ -4443,7 +4443,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: ovirt
       ci-operator.openshift.io/cloud-cluster-profile: ovirt
@@ -4528,7 +4528,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: ovirt
       ci-operator.openshift.io/cloud-cluster-profile: ovirt
@@ -4613,7 +4613,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -4698,7 +4698,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4783,7 +4783,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4868,7 +4868,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4953,7 +4953,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5038,7 +5038,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5123,7 +5123,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5208,7 +5208,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5265,7 +5265,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -5351,7 +5351,7 @@ presubmits:
     decorate: true
     decoration_config:
       sparse_checkout_files:
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/variant: okd-scos
       ci.openshift.io/generator: prowgen
@@ -5411,7 +5411,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5494,7 +5494,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5559,7 +5559,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5624,7 +5624,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-periodics.yaml
@@ -5,14 +5,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -102,14 +102,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -199,14 +199,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -296,14 +296,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -393,14 +393,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -490,14 +490,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -586,14 +586,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -683,14 +683,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -780,14 +780,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -877,14 +877,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -965,14 +965,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     capability/nested-podman: nested-podman
@@ -1054,14 +1054,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -1150,14 +1150,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -1246,14 +1246,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: azure4
@@ -1342,14 +1342,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: azure4
@@ -1439,14 +1439,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: azure4
@@ -1536,14 +1536,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: azure4
@@ -1633,14 +1633,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
@@ -1729,14 +1729,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
@@ -1826,14 +1826,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
@@ -1923,14 +1923,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
@@ -2021,14 +2021,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2119,14 +2119,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2217,14 +2217,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2315,14 +2315,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2413,14 +2413,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2511,14 +2511,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2609,14 +2609,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2707,14 +2707,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2805,14 +2805,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2903,14 +2903,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3001,14 +3001,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3099,14 +3099,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3197,14 +3197,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3295,14 +3295,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3393,14 +3393,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3491,14 +3491,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     ci-operator.openshift.io/cloud: vsphere
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -3587,14 +3587,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     ci-operator.openshift.io/cloud: vsphere
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -3683,14 +3683,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   extra_refs:
   - base_ref: release-4.23
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel9
   labels:
     ci-operator.openshift.io/cloud: vsphere
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-4.23-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/variant: arm64-periodics
       ci.openshift.io/generator: prowgen
@@ -71,7 +71,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -137,7 +137,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -223,7 +223,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -309,7 +309,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -394,7 +394,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -489,7 +489,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -573,7 +573,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -658,7 +658,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -743,7 +743,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -828,7 +828,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -915,7 +915,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -999,7 +999,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1084,7 +1084,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1169,7 +1169,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1254,7 +1254,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1339,7 +1339,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1424,7 +1424,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1509,7 +1509,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1594,7 +1594,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1679,7 +1679,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1764,7 +1764,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1849,7 +1849,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -1934,7 +1934,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2019,7 +2019,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2104,7 +2104,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2189,7 +2189,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2274,7 +2274,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2367,7 +2367,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2452,7 +2452,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2537,7 +2537,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2624,7 +2624,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2710,7 +2710,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
       timeout: 4h0m0s
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -2797,7 +2797,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2881,7 +2881,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2966,7 +2966,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3051,7 +3051,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3136,7 +3136,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3221,7 +3221,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3306,7 +3306,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3393,7 +3393,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -3477,7 +3477,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -3562,7 +3562,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: packet-edge
@@ -3648,7 +3648,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3734,7 +3734,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3820,7 +3820,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: equinix-edge-enablement
       ci-operator.openshift.io/cloud-cluster-profile: equinix-edge-enablement
@@ -3905,7 +3905,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: equinix-edge-enablement
       ci-operator.openshift.io/cloud-cluster-profile: equinix-edge-enablement
@@ -3990,7 +3990,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
@@ -4076,7 +4076,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: openstack-hwoffload
       ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
@@ -4161,7 +4161,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: openstack-vh-mecha-central
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
@@ -4246,7 +4246,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -4331,7 +4331,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
@@ -4416,7 +4416,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: openstack-hwoffload
       ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
@@ -4501,7 +4501,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: ovirt
       ci-operator.openshift.io/cloud-cluster-profile: ovirt
@@ -4586,7 +4586,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: ovirt
       ci-operator.openshift.io/cloud-cluster-profile: ovirt
@@ -4671,7 +4671,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -4756,7 +4756,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4841,7 +4841,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4926,7 +4926,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5011,7 +5011,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5096,7 +5096,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5181,7 +5181,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5266,7 +5266,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5324,7 +5324,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci-operator.openshift.io/variant: periodics
       ci.openshift.io/generator: prowgen
@@ -5384,7 +5384,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5467,7 +5467,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5532,7 +5532,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5597,7 +5597,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel9
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-periodics.yaml
@@ -5,14 +5,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -102,14 +102,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -199,14 +199,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -296,14 +296,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -393,14 +393,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -490,14 +490,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -586,14 +586,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -683,14 +683,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -780,14 +780,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -877,14 +877,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -965,14 +965,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 168h
   labels:
     capability/nested-podman: nested-podman
@@ -1054,14 +1054,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -1150,14 +1150,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: aws
@@ -1246,14 +1246,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: azure4
@@ -1342,14 +1342,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: azure4
@@ -1439,14 +1439,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: azure4
@@ -1536,14 +1536,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: azure4
@@ -1633,14 +1633,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
@@ -1729,14 +1729,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: gcp
@@ -1826,14 +1826,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: gcp
@@ -1923,14 +1923,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   interval: 24h
   labels:
     ci-operator.openshift.io/cloud: gcp
@@ -2021,14 +2021,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2119,14 +2119,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2217,14 +2217,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2315,14 +2315,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2413,14 +2413,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2511,14 +2511,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2609,14 +2609,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2707,14 +2707,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2805,14 +2805,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -2903,14 +2903,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3001,14 +3001,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3099,14 +3099,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3197,14 +3197,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3295,14 +3295,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3393,14 +3393,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     capability/intranet: intranet
     ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3491,14 +3491,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     ci-operator.openshift.io/cloud: vsphere
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -3587,14 +3587,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     ci-operator.openshift.io/cloud: vsphere
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -3683,14 +3683,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     ci-operator.openshift.io/cloud: vsphere
     ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -3771,14 +3771,14 @@ periodics:
   decoration_config:
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   extra_refs:
   - base_ref: release-5.0
     org: openshift
     repo: machine-config-operator
     sparse_checkout_files:
     - .ci-operator.yaml
-    - Dockerfile.rhel7
+    - Dockerfile.rhel10
   labels:
     ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.0-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/variant: arm64-periodics
       ci.openshift.io/generator: prowgen
@@ -71,7 +71,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -137,7 +137,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -223,7 +223,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -309,7 +309,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -394,7 +394,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -489,7 +489,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -573,7 +573,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -658,7 +658,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -743,7 +743,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -828,7 +828,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -915,7 +915,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -999,7 +999,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1084,7 +1084,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1169,7 +1169,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1254,7 +1254,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1339,7 +1339,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1424,7 +1424,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1509,7 +1509,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1594,7 +1594,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1679,7 +1679,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1764,7 +1764,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1849,7 +1849,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -1934,7 +1934,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2019,7 +2019,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2104,7 +2104,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2189,7 +2189,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2274,7 +2274,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2367,7 +2367,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2452,7 +2452,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2537,7 +2537,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2624,7 +2624,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2710,7 +2710,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
       timeout: 4h0m0s
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -2797,7 +2797,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2881,7 +2881,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2966,7 +2966,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3051,7 +3051,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3136,7 +3136,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3221,7 +3221,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3306,7 +3306,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3393,7 +3393,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -3477,7 +3477,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -3562,7 +3562,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: packet-edge
@@ -3648,7 +3648,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3734,7 +3734,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3820,7 +3820,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: equinix-edge-enablement
       ci-operator.openshift.io/cloud-cluster-profile: equinix-edge-enablement
@@ -3905,7 +3905,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: equinix-edge-enablement
       ci-operator.openshift.io/cloud-cluster-profile: equinix-edge-enablement
@@ -3990,7 +3990,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
@@ -4076,7 +4076,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-hwoffload
       ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
@@ -4161,7 +4161,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vh-mecha-central
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
@@ -4246,7 +4246,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -4331,7 +4331,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
@@ -4416,7 +4416,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-hwoffload
       ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
@@ -4501,7 +4501,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: ovirt
       ci-operator.openshift.io/cloud-cluster-profile: ovirt
@@ -4586,7 +4586,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: ovirt
       ci-operator.openshift.io/cloud-cluster-profile: ovirt
@@ -4671,7 +4671,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -4756,7 +4756,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4841,7 +4841,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4926,7 +4926,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5011,7 +5011,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5096,7 +5096,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5181,7 +5181,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5266,7 +5266,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5323,7 +5323,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/variant: periodics
       ci.openshift.io/generator: prowgen
@@ -5383,7 +5383,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5466,7 +5466,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5531,7 +5531,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5596,7 +5596,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.1-postsubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.1-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.1-presubmits.yaml
+++ b/ci-operator/jobs/openshift/machine-config-operator/openshift-machine-config-operator-release-5.1-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -77,7 +77,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -163,7 +163,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -249,7 +249,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -334,7 +334,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -429,7 +429,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -513,7 +513,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -598,7 +598,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -683,7 +683,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -768,7 +768,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -855,7 +855,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -939,7 +939,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1024,7 +1024,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1109,7 +1109,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1194,7 +1194,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1279,7 +1279,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1364,7 +1364,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1449,7 +1449,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1534,7 +1534,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1619,7 +1619,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1704,7 +1704,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -1789,7 +1789,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -1874,7 +1874,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -1959,7 +1959,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2044,7 +2044,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2129,7 +2129,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-azure
@@ -2214,7 +2214,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2307,7 +2307,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2392,7 +2392,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2477,7 +2477,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2564,7 +2564,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2650,7 +2650,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
       timeout: 4h0m0s
     labels:
       ci-operator.openshift.io/cloud: gcp
@@ -2737,7 +2737,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2821,7 +2821,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2906,7 +2906,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -2991,7 +2991,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3076,7 +3076,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3161,7 +3161,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3246,7 +3246,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: gcp
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
@@ -3333,7 +3333,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -3417,7 +3417,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -3502,7 +3502,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: packet-edge
@@ -3588,7 +3588,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3674,7 +3674,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: equinix-ocp-metal
@@ -3760,7 +3760,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: equinix-edge-enablement
       ci-operator.openshift.io/cloud-cluster-profile: equinix-edge-enablement
@@ -3845,7 +3845,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: equinix-edge-enablement
       ci-operator.openshift.io/cloud-cluster-profile: equinix-edge-enablement
@@ -3930,7 +3930,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
@@ -4016,7 +4016,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-hwoffload
       ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
@@ -4101,7 +4101,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vh-mecha-central
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vh-mecha-central
@@ -4186,7 +4186,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: hypershift-aws
       ci-operator.openshift.io/cloud-cluster-profile: hypershift-aws
@@ -4271,7 +4271,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-vexxhost
       ci-operator.openshift.io/cloud-cluster-profile: openstack-vexxhost
@@ -4356,7 +4356,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: openstack-hwoffload
       ci-operator.openshift.io/cloud-cluster-profile: openstack-hwoffload
@@ -4441,7 +4441,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: ovirt
       ci-operator.openshift.io/cloud-cluster-profile: ovirt
@@ -4526,7 +4526,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: ovirt
       ci-operator.openshift.io/cloud-cluster-profile: ovirt
@@ -4611,7 +4611,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: openshift-org-aws
@@ -4696,7 +4696,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4781,7 +4781,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4866,7 +4866,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -4951,7 +4951,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5036,7 +5036,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5121,7 +5121,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci-operator.openshift.io/cloud: vsphere
       ci-operator.openshift.io/cloud-cluster-profile: vsphere-elastic
@@ -5206,7 +5206,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5264,7 +5264,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5347,7 +5347,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5412,7 +5412,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -5477,7 +5477,7 @@ presubmits:
     decoration_config:
       sparse_checkout_files:
       - .ci-operator.yaml
-      - Dockerfile.rhel7
+      - Dockerfile.rhel10
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
By separating the MCO images into RHEL9 and RHEL10 configs, we're able to specify which release should get which RHEL version installed by default. The changes in this PR will have the following effects:

- All OCP presubmits which run on `main` and `5.0` will begin using RHEL10 by default, even though we are still technically in 4.23.
- All OCP presubmits which run specifically on `release-4.23` will continue to use RHEL9 by default for presubmits. This will apply to any periodics as well which specifically target `release-4.23`.
