### PR TITLE
Acm sf multicloud operators foundation e2e fix

### DIFF
--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.10.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.10.yaml
@@ -90,14 +90,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=backplane-2.10
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.11.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.11.yaml
@@ -94,14 +94,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=backplane-2.11
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.17.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.17.yaml
@@ -94,14 +94,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=backplane-2.17
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.6.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.6.yaml
@@ -86,14 +86,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=backplane-2.6
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.7.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.7.yaml
@@ -90,14 +90,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=backplane-2.7
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.8.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.8.yaml
@@ -86,14 +86,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=backplane-2.8
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.9.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-2.9.yaml
@@ -90,14 +90,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=backplane-2.9
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-5.0.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-5.0.yaml
@@ -94,7 +94,7 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_BRANCH=main
+        OCM_BRANCH=backplane-5.0
         REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
         OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
         REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-5.0.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-backplane-5.0.yaml
@@ -94,14 +94,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=main
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail

--- a/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-main.yaml
+++ b/ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-main.yaml
@@ -90,14 +90,15 @@ tests:
       commands: |
         export KUBECONFIG="${SHARED_DIR}/hub-1.kc"
         KUBECTL=oc
-        OCM_VERSION=main
-        REGISTRATION_OPERATOR_BRANCH=$OCM_VERSION
-        IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_VERSION
-        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_VERSION
-        WORK_IMAGE=quay.io/stolostron/work:$OCM_VERSION
-        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_VERSION
-        export KUBECTL IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE REGISTRATION_OPERATOR_BRANCH
-        export KUBECTL
+        OCM_BRANCH=main
+        REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH
+        OPERATOR_IMAGE_NAME=quay.io/stolostron/registration-operator:$OCM_BRANCH
+        REGISTRATION_IMAGE=quay.io/stolostron/registration:$OCM_BRANCH
+        WORK_IMAGE=quay.io/stolostron/work:$OCM_BRANCH
+        PLACEMENT_IMAGE=quay.io/stolostron/placement:$OCM_BRANCH
+        ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH}
+        export KUBECTL REGISTRATION_OPERATOR_BRANCH OCM_BRANCH
+        export OPERATOR_IMAGE_NAME REGISTRATION_IMAGE WORK_IMAGE PLACEMENT_IMAGE ADDON_MANAGER_IMAGE
         set -o pipefail
         make test-e2e 2>&1 | tee ${ARTIFACT_DIR}/e2e_tests_out.log
         set +o pipefail


### PR DESCRIPTION
Multicloud-operators-foundation previously used main in many places for image tags when deploying other components for e2e testing.

In some older release branches, some addon images would use the appropriate "branch-x.y" tag, but recent ones all default to `main`.

Additionally, `ADDON_MANAGER_IMAGE` was never specified, so it was actually falling back to the open-cluster-management-io image: `quay.io/open-cluster-management/addon-manager:latest ` where other images would be set to the stolstron equivalent.

So fixes:
- Use the proper branch-x.y tag generally instead of hardcoding `main`.  Note that main/backplane-5.0 still use `main`
- set ADDON_MANAGER_IMAGE so we're picking up the stolostron image.

Not fixed:
- the CLUSTER_PROXY image is still hardcoded to use the `main` tag - this fix will need to be done in https://github.com/stolostron/multicloud-operators-foundation/blob/89634a74478f2f2f1931730eb28ee9713651d7ce/deploy/managedcluster/addons/install.sh#L68 (across all branches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates OpenShift CI configuration for the Stolostron multicloud-operators-foundation component so e2e jobs use branch-aligned Stolostron-built images instead of defaulting to :main (and fixes a missing addon-manager image).

## Practical impact / scope

- Affects CI/Prow job definitions for stolostron/multicloud-operators-foundation under ci-operator/config/stolostron/multicloud-operators-foundation/.
- Ensures e2e tests for each release branch pull operator and component images tagged from the matching Stolostron branch, preventing cross-branch image skew during rehearsals and CI runs.

## Problem addressed

- Many e2e jobs previously hardcoded or defaulted to :main (OCM_VERSION=main), causing tests for older release branches to pull main images instead of branch-specific images.
- ADDON_MANAGER_IMAGE was not explicitly set, causing a fallback to quay.io/open-cluster-management/addon-manager:latest rather than the Stolostron-built addon-manager.

## Changes made

Updated the e2e step in the CI configs for the following jobs to derive image tags from a branch variable and explicitly export the addon-manager image:
- backplane-2.6
- backplane-2.7
- backplane-2.8
- backplane-2.9
- backplane-2.10
- backplane-2.11
- backplane-2.17
- backplane-5.0
- main

Concretely:
- Replaced OCM_VERSION=main usage with OCM_BRANCH=<branch> (e.g., OCM_BRANCH=backplane-2.10 or OCM_BRANCH=main).
- Set REGISTRATION_OPERATOR_BRANCH=$OCM_BRANCH.
- Constructed operator/component image references from quay.io/stolostron/*:$OCM_BRANCH (OPERATOR_IMAGE_NAME, REGISTRATION_IMAGE, WORK_IMAGE, PLACEMENT_IMAGE).
- Added ADDON_MANAGER_IMAGE=quay.io/stolostron/addon-manager:${OCM_BRANCH} and export it so tests use the Stolostron addon-manager image.
- Standardized renaming IMAGE_NAME → OPERATOR_IMAGE_NAME and adjusted exported variable lists.

Files updated: ci-operator/config/stolostron/multicloud-operators-foundation/stolostron-multicloud-operators-foundation-{main,backplane-5.0,backplane-2.6,2.7,2.8,2.9,2.10,2.11,2.17}.yaml

## Known limitations / notes

- CLUSTER_PROXY image remains hardcoded to main; that change must be made upstream in the multicloud-operators-foundation repository (deploy/managedcluster/addons/install.sh) across branches.
- backplane-5.0 now uses its branch tag (backplane-5.0) and main uses OCM_BRANCH=main as shown in the updated CI configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->