### PR TITLE
Fix ginkgo label-filter quoting in rosa-e2e test step

### DIFF
--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
@@ -62,7 +62,7 @@ fi
 # Run tests
 GINKGO_FLAGS="--ginkgo.junit-report=${ARTIFACT_DIR}/junit-rosa-e2e.xml --ginkgo.v"
 if [[ -n "${LABEL_FILTER}" ]]; then
-  GINKGO_FLAGS="${GINKGO_FLAGS} --ginkgo.label-filter=${LABEL_FILTER}"
+  GINKGO_FLAGS="${GINKGO_FLAGS} --ginkgo.label-filter '${LABEL_FILTER}'"
 fi
 
 if [[ -n "${CLUSTER_TOPOLOGY:-}" ]]; then

--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
@@ -61,7 +61,8 @@ fi
 
 # Run tests
 GINKGO_FLAGS="--ginkgo.junit-report=${ARTIFACT_DIR}/junit-rosa-e2e.xml --ginkgo.v"
-if [[ -n "${LABEL_FILTER}" ]]; then
+log "LABEL_FILTER='${LABEL_FILTER:-}'"
+if [[ -n "${LABEL_FILTER:-}" ]]; then
   GINKGO_FLAGS="${GINKGO_FLAGS} --ginkgo.label-filter '${LABEL_FILTER}'"
 fi
 
@@ -69,11 +70,11 @@ if [[ -n "${CLUSTER_TOPOLOGY:-}" ]]; then
   export CLUSTER_TOPOLOGY
 fi
 
-if [[ -n "${EXCLUDE_CLUSTER_OPERATORS}" ]]; then
+if [[ -n "${EXCLUDE_CLUSTER_OPERATORS:-}" ]]; then
   export EXCLUDE_CLUSTER_OPERATORS
 fi
 
-log "Running rosa-e2e tests..."
+log "Running rosa-e2e tests: /usr/local/bin/e2e.test ${GINKGO_FLAGS}"
 /usr/local/bin/e2e.test ${GINKGO_FLAGS}
 
 log "Tests complete. Results at ${ARTIFACT_DIR}/junit-rosa-e2e.xml"


### PR DESCRIPTION
The --ginkgo.label-filter flag was passed using the = form (--ginkgo.label-filter=!Access:MC) which ginkgo was not parsing correctly. Access:MC labeled tests were still running despite the filter. Switch to space-separated form with proper quoting to ensure the filter expression is parsed correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes how the ginkgo label-filter flag is passed in the ROSA e2e test execution within OpenShift's CI infrastructure.

### Problem
The ginkgo label-filter flag was being supplied using the equals form (`--ginkgo.label-filter=!Access:MC`), which ginkgo did not parse correctly, causing filter expressions to be ignored and allowing tests with excluded labels to run.

### Solution
Changed the flag from the equals form to a space-separated form with proper quoting (`--ginkgo.label-filter '${LABEL_FILTER}'`), enabling ginkgo to correctly parse filter expressions like `!Access:MC`.

### Additional Improvements
- Added debug logging to output the `LABEL_FILTER` value for CI diagnostics
- Added debug logging to print the full e2e.test invocation including computed `GINKGO_FLAGS`
- Updated variable checks to use `${VAR:-}` syntax to avoid nounset errors when variables are unset
- Added conditional exports for `CLUSTER_TOPOLOGY` and `EXCLUDE_CLUSTER_OPERATORS` using the same pattern

### Files Changed
- `ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh`: Updated test setup to fix flag quoting and add debugging output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->