### PR TITLE
WIP: fix: resolve lint markdown job failure

### DIFF
--- a/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
+++ b/ci-operator/config/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main.yaml
@@ -3,6 +3,10 @@ base_images:
     name: claude-ai-helpers
     namespace: ci
     tag: latest
+  promotedmarkdownlint:
+    name: markdownlint-cli2
+    namespace: ci
+    tag: latest
   shellcheck:
     name: shellcheck
     namespace: ci
@@ -37,15 +41,13 @@ resources:
 tests:
 - always_run: false
   as: markdownlint
-  commands: make lint-markdown
+  commands: pwd && ls -la && cat Makefile && make lint-markdown
   container:
-    clone: true
-    from: markdownlint-cli2
+    from: promotedmarkdownlint
   run_if_changed: (\.md|^Makefile|^hack/.*markdown.*|^\.markdown.*)$
 - as: shellcheck
   commands: make lint-shellcheck
   container:
-    clone: true
     from: shellcheck
   run_if_changed: .sh$
 - as: ocp-ci-monitor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chore**
  * CI presubmit now runs additional workspace diagnostics (prints working directory, lists files, shows Makefile) before invoking the markdown lint step.
  * The markdown lint job now uses a promoted markdownlint base image alias instead of the previous direct container reference.

* **Bug Fix**
  * Removed an earlier container clone setting from the markdown lint job configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->