### PR TITLE
freshening OLM QE user lists for labels

### DIFF
--- a/core-services/prow/02_config/openshift/cluster-olm-operator/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/cluster-olm-operator/_pluginconfig.yaml
@@ -7,10 +7,7 @@ label:
   restricted_labels:
     openshift/cluster-olm-operator:
     - allowed_users:
-      - jianzhangbjz
-      - kuiwang02
       - bandrade
-      - Xia-Zhao-rh
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
@@ -20,7 +17,6 @@ label:
       - gavinmbell
       - joelanford
       - oceanc80
-      - jianzhangbjz
       label: backport-risk-assessed
 lgtm:
 - repos:

--- a/core-services/prow/02_config/openshift/operator-framework-olm/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/operator-framework-olm/_pluginconfig.yaml
@@ -7,10 +7,7 @@ label:
   restricted_labels:
     openshift/operator-framework-olm:
     - allowed_users:
-      - jianzhangbjz
-      - kuiwang02
       - bandrade
-      - Xia-Zhao-rh
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
@@ -20,7 +17,6 @@ label:
       - gavinmbell
       - joelanford
       - oceanc80
-      - jianzhangbjz
       label: backport-risk-assessed
 lgtm:
 - repos:

--- a/core-services/prow/02_config/openshift/operator-framework-operator-controller/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift/operator-framework-operator-controller/_pluginconfig.yaml
@@ -7,10 +7,7 @@ label:
   restricted_labels:
     openshift/operator-framework-operator-controller:
     - allowed_users:
-      - jianzhangbjz
-      - kuiwang02
       - bandrade
-      - Xia-Zhao-rh
       assign_on:
       - label: backport-risk-assessed
       label: cherry-pick-approved
@@ -20,7 +17,6 @@ label:
       - gavinmbell
       - joelanford
       - oceanc80
-      - jianzhangbjz
       label: backport-risk-assessed
 lgtm:
 - repos:


### PR DESCRIPTION
Recently the user lists were updated, but as of yet no new folks were identified to replace them, so this PR just removes the folks who aren't available anymore. 😢 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Freshening OLM QE user lists for labels

This PR removes four unavailable users from OpenShift CI's Prow authorization configurations for the OLM (Operator Lifecycle Manager) ecosystem projects. The changes affect label approval permissions across three operator framework repositories:

- `cluster-olm-operator` — the base OLM cluster operator
- `operator-framework-olm` — the OLM runtime
- `operator-framework-operator-controller` — the operator controller

**Practical impact:** The removed users (`jianzhangbjz`, `kuiwang02`, `Xia-Zhao-rh`) are no longer authorized to approve or apply restricted labels in pull requests to these repositories. Only `bandrade` remains authorized for these operations. This prevents unavailable team members from being listed as approvers for OLM-related CI workflows, ensuring the approval chains reflect current team availability. As noted in the PR description, replacements for the departed users have not yet been identified, so these entries are being deleted pending future assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->