### PR TITLE
Create Prow jobs for standalone-distributed-tracing-3.10 release branch

### DIFF
--- a/ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-docs-3.10.yaml
+++ b/ci-operator/config/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-docs-3.10.yaml
@@ -1,0 +1,38 @@
+build_root:
+  image_stream_tag:
+    name: openshift-docs-asciidoc
+    namespace: ocp
+    tag: latest
+  use_build_cache: true
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 400m
+      memory: 800Mi
+tests:
+- as: validate-asciidoc
+  steps:
+    env:
+      DISTROS: openshift-distributed-tracing
+      PREVIEW_SITE: ocpdocs-pr
+    test:
+    - ref: openshift-docs-build-docs
+    - ref: openshift-docs-preview-comment-pages
+    - ref: openshift-docs-asciidoctor
+    - ref: openshift-docs-lint-topicmaps
+    - ref: openshift-docs-jira-links
+    - ref: openshift-docs-vale-review
+- as: validate-portal
+  steps:
+    env:
+      BUILD: build_for_portal.py
+      DISTROS: openshift-distributed-tracing
+      VERSION: "3.10"
+    test:
+    - ref: openshift-docs-portal
+zz_generated_metadata:
+  branch: standalone-distributed-tracing-docs-3.10
+  org: openshift
+  repo: openshift-docs

--- a/ci-operator/jobs/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-docs-3.10-presubmits.yaml
+++ b/ci-operator/jobs/openshift/openshift-docs/openshift-openshift-docs-standalone-distributed-tracing-docs-3.10-presubmits.yaml
@@ -1,0 +1,148 @@
+presubmits:
+  openshift/openshift-docs:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^standalone-distributed-tracing-docs-3\.10$
+    - ^standalone-distributed-tracing-docs-3\.10-
+    cluster: build01
+    context: ci/prow/validate-asciidoc
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-docs-standalone-distributed-tracing-docs-3.10-validate-asciidoc
+    rerun_command: /test validate-asciidoc
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-asciidoc
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-asciidoc,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^standalone-distributed-tracing-docs-3\.10$
+    - ^standalone-distributed-tracing-docs-3\.10-
+    cluster: build01
+    context: ci/prow/validate-portal
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-openshift-docs-standalone-distributed-tracing-docs-3.10-validate-portal
+    rerun_command: /test validate-portal
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --target=validate-portal
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )validate-portal,?($|\s.*)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds Prow job configuration for the openshift-docs repository to support the new `standalone-distributed-tracing-3.10` release branch.

## Changes

A new CI operator configuration file has been created that establishes the build and test infrastructure for the standalone distributed tracing documentation on the 3.10 release branch. The configuration includes:

- **Build environment**: Uses the `openshift-docs-asciidoc` image stream from the `ocp` namespace with resource constraints (4Gi memory limit, 400m CPU and 800Mi memory requests)
- **Validation jobs**: Introduces two automated testing jobs:
  - `validate-asciidoc`: Validates documentation source files with support for multiple distributions
  - `validate-portal`: Validates documentation portal generation using the build_for_portal.py script
- **Version targeting**: Explicitly configured for the 3.10 documentation version

This configuration enables automated testing and validation of documentation changes for the standalone distributed tracing 3.10 release when code is pushed to the corresponding release branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->