### PR TITLE
switch rhoe 4.18 cluster pool to SNO clusters

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/sno/install-config-4-18-sno-amd64-aws-us-east-1_secret.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/sno/install-config-4-18-sno-amd64-aws-us-east-1_secret.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: install-config-4-18-sno-amd64-aws-us-east-1
+  namespace: rhoe-cluster-pool
+stringData:
+  install-config.yaml: |
+    apiVersion: v1
+    baseDomain: certification-pipeline.opdev.io
+    compute:
+    - architecture: amd64
+      hyperthreading: Enabled
+      name: worker
+      platform:
+        aws:
+          type: m7i.2xlarge
+      replicas: 0
+    controlPlane:
+      architecture: amd64
+      hyperthreading: Enabled
+      name: master
+      platform:
+        aws:
+          type: m7i.2xlarge
+      replicas: 1
+    metadata:
+      creationTimestamp: null
+      name: hive01
+    networking:
+      clusterNetwork:
+      - cidr: 10.128.0.0/14
+        hostPrefix: 23
+      machineNetwork:
+      - cidr: 10.0.0.0/16
+      networkType: OVNKubernetes
+      serviceNetwork:
+      - 172.30.0.0/16
+    platform:
+      aws:
+        region: us-east-1
+    publish: External
+    sshKey: |
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKNaYiC98tMIzsr4A9n/b75z9hCNMCT3omNbyR7YeAQT
+
+type: Opaque

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/sno/install-config-4-18-sno-amd64-aws-us-east-2_secret.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/sno/install-config-4-18-sno-amd64-aws-us-east-2_secret.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: install-config-4-18-sno-amd64-aws-us-east-2
+  namespace: rhoe-cluster-pool
+stringData:
+  install-config.yaml: |
+    apiVersion: v1
+    baseDomain: certification-pipeline.opdev.io
+    compute:
+    - architecture: amd64
+      hyperthreading: Enabled
+      name: worker
+      platform:
+        aws:
+          type: m7i.2xlarge
+      replicas: 0
+    controlPlane:
+      architecture: amd64
+      hyperthreading: Enabled
+      name: master
+      platform:
+        aws:
+          type: m7i.2xlarge
+      replicas: 1
+    metadata:
+      creationTimestamp: null
+      name: hive01
+    networking:
+      clusterNetwork:
+      - cidr: 10.128.0.0/14
+        hostPrefix: 23
+      machineNetwork:
+      - cidr: 10.0.0.0/16
+      networkType: OVNKubernetes
+      serviceNetwork:
+      - 172.30.0.0/16
+    platform:
+      aws:
+        region: us-east-2
+    publish: External
+    sshKey: |
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKNaYiC98tMIzsr4A9n/b75z9hCNMCT3omNbyR7YeAQT
+
+type: Opaque

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/sno/rhoe-ocp-4-18-sno-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/sno/rhoe-ocp-4-18-sno-amd64-aws-us-east-1_clusterpool.yaml
@@ -11,7 +11,7 @@ metadata:
     version_lower: 4.18.0-0
     version_stream: 4-stable
     version_upper: 4.19.0-0
-  name: rhoe-ocp-4-18-amd64-aws-us-east-1
+  name: rhoe-ocp-4-18-sno-amd64-aws-us-east-1
   namespace: rhoe-cluster-pool
 spec:
   baseDomain: certification-pipeline.opdev.io
@@ -21,7 +21,7 @@ spec:
     name: ocp-release-4.18.39-multi-for-4.18.0-0-to-4.19.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
-    name: install-config-4-18-amd64-aws-us-east-1
+    name: install-config-4-18-sno-amd64-aws-us-east-1
   labels:
     tp.openshift.io/owner: rh-openshift-ecosystem
   maxSize: 10
@@ -32,7 +32,8 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 0
+  runningCount: 2
+  size: 2
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/sno/rhoe-ocp-4-18-sno-amd64-aws-us-east-2_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/sno/rhoe-ocp-4-18-sno-amd64-aws-us-east-2_clusterpool.yaml
@@ -11,7 +11,7 @@ metadata:
     version_lower: 4.18.0-0
     version_stream: 4-stable
     version_upper: 4.19.0-0
-  name: rhoe-ocp-4-18-amd64-aws-us-east-1
+  name: rhoe-ocp-4-18-sno-amd64-aws-us-east-2
   namespace: rhoe-cluster-pool
 spec:
   baseDomain: certification-pipeline.opdev.io
@@ -21,7 +21,7 @@ spec:
     name: ocp-release-4.18.39-multi-for-4.18.0-0-to-4.19.0-0
   installAttemptsLimit: 1
   installConfigSecretTemplateRef:
-    name: install-config-4-18-amd64-aws-us-east-1
+    name: install-config-4-18-sno-amd64-aws-us-east-2
   labels:
     tp.openshift.io/owner: rh-openshift-ecosystem
   maxSize: 10
@@ -29,7 +29,7 @@ spec:
     aws:
       credentialsSecretRef:
         name: rh-openshift-ecosystem-aws-credentials
-      region: us-east-1
+      region: us-east-2
   pullSecretRef:
     name: pull-secret
   size: 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## OpenShift CI Infrastructure: Migrating RH OpenShift Ecosystem 4.18 Cluster Pool to Single Node OpenShift

This PR transitions the Red Hat OpenShift Ecosystem certification testing infrastructure for OpenShift 4.18 from multi-node clusters to Single Node OpenShift (SNO) clusters.

### What Changed

**New SNO Cluster Pools Added:**
- Two new SNO cluster pools created for OCP 4.18 (in `sno/` subdirectory):
  - `rhoe-ocp-4-18-sno-amd64-aws-us-east-1` (AWS us-east-1 region)
  - `rhoe-ocp-4-18-sno-amd64-aws-us-east-2` (AWS us-east-2 region)
- Both pools configured with `size: 2` and `runningCount: 2`, ready to spawn test clusters

**SNO Configuration Details:**
- Single control plane node (`replicas: 1` for master)
- Zero worker nodes (`replicas: 0` for compute)
- Uses `m7i.2xlarge` AWS instance type
- OVN Kubernetes networking
- Hibernation enabled with 20-minute resume timeout

**Supporting Configuration:**
- Two new Kubernetes Secrets added with SNO-specific OpenShift install configurations:
  - `install-config-4-18-sno-amd64-aws-us-east-1_secret.yaml`
  - `install-config-4-18-sno-amd64-aws-us-east-2_secret.yaml`

**Existing Non-SNO Pool:**
- The original multi-node cluster pool (`rhoe-ocp-4-18-amd64-aws-us-east-1`) remains in place but with `size: 0` (disabled)

### Impact

This change affects Red Hat OpenShift Ecosystem's CI testing pipeline for OCP 4.18 certification validation. The shift to SNO clusters reduces resource consumption while enabling faster cluster provisioning for certification tests, which is particularly useful for rapid validation cycles and resource-constrained testing scenarios. The existing multi-node configuration is being phased out in favor of the lighter-weight SNO approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->