### PR TITLE
Prepare RHCS tests for OCP 4.22

### DIFF
--- a/ci-operator/config/terraform-redhat/terraform-provider-rhcs/terraform-redhat-terraform-provider-rhcs-main__e2e.yaml
+++ b/ci-operator/config/terraform-redhat/terraform-provider-rhcs/terraform-redhat-terraform-provider-rhcs-main__e2e.yaml
@@ -35,12 +35,13 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       CASE_LABEL_FILTER: (Critical,High)&&(day1-post,day2)&&!Exclude
-      CHANNEL_GROUP: stable
+      CHANNEL_GROUP: candidate
       CLUSTER_PROFILE: rosa-sts-ad
       QE_USAGE: rosa-sts-advanced-critical-high-f3
       REGION: ap-northeast-1
       RHCS_CLUSTER_NAME_SUFFIX: f3
       RHCS_URL: https://api.stage.openshift.com
+      VERSION: 4.22.0-rc.3
       WAIT_OPERATORS: "false"
     test:
     - ref: rhcs-e2e-tests
@@ -62,12 +63,13 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       CASE_LABEL_FILTER: (Critical,High)&&(day1-post,day2)&&!Exclude
-      CHANNEL_GROUP: stable
+      CHANNEL_GROUP: candidate
       CLUSTER_PROFILE: rosa-sts-pl
       QE_USAGE: rosa-sts-private-critical-high-f3
       REGION: us-east-1
       RHCS_CLUSTER_NAME_SUFFIX: f3
       RHCS_URL: https://api.stage.openshift.com
+      VERSION: 4.22.0-rc.3
       WAIT_OPERATORS: "false"
     test:
     - ref: rhcs-e2e-tests
@@ -89,13 +91,14 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       CASE_LABEL_FILTER: (Critical,High)&&(day1-post,day2)&&!Exclude
-      CHANNEL_GROUP: stable
+      CHANNEL_GROUP: candidate
       CLUSTER_PROFILE: rosa-sts-sv
       ENABLE_SHARED_VPC: "yes"
       QE_USAGE: rosa-sts-shared-vpc-critical-high-f3
       REGION: us-east-1
       RHCS_CLUSTER_NAME_SUFFIX: f3
       RHCS_URL: https://api.stage.openshift.com
+      VERSION: 4.22.0-rc.3
       WAIT_OPERATORS: "false"
     test:
     - ref: rhcs-e2e-tests
@@ -117,12 +120,13 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       CASE_LABEL_FILTER: (Medium,Low)&&(day1-post,day2)&&!Exclude
-      CHANNEL_GROUP: stable
+      CHANNEL_GROUP: candidate
       CLUSTER_PROFILE: rosa-sts-ad
       QE_USAGE: rosa-sts-advanced-medium-low-f7
       REGION: ap-northeast-1
       RHCS_CLUSTER_NAME_SUFFIX: f7
       RHCS_URL: https://api.stage.openshift.com
+      VERSION: 4.22.0-rc.3
       WAIT_OPERATORS: "true"
     test:
     - ref: rhcs-e2e-tests
@@ -335,12 +339,13 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       CASE_LABEL_FILTER: (Critical,High)&&(day1-post,day2)&&!Exclude
-      CHANNEL_GROUP: stable
+      CHANNEL_GROUP: candidate
       CLUSTER_PROFILE: rosa-hcp-ad
       QE_USAGE: rosa-hcp-advanced-critical-high-f3
       REGION: us-west-2
       RHCS_CLUSTER_NAME_SUFFIX: f3
       RHCS_URL: https://api.stage.openshift.com
+      VERSION: 4.22.0-rc.3
       WAIT_OPERATORS: "false"
     test:
     - ref: rhcs-e2e-tests
@@ -362,12 +367,13 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       CASE_LABEL_FILTER: (Medium,Low)&&(day1-post,day2)&&!Exclude
-      CHANNEL_GROUP: stable
+      CHANNEL_GROUP: candidate
       CLUSTER_PROFILE: rosa-hcp-ad
       QE_USAGE: rosa-hcp-advanced-medium-low-f7
       REGION: us-west-2
       RHCS_CLUSTER_NAME_SUFFIX: f7
       RHCS_URL: https://api.stage.openshift.com
+      VERSION: 4.22.0-rc.3
       WAIT_OPERATORS: "true"
     test:
     - ref: rhcs-e2e-tests
@@ -389,12 +395,13 @@ tests:
     cluster_profile: oex-aws-qe
     env:
       CASE_LABEL_FILTER: (Critical,High)&&(day1-post,day2)&&!Exclude
-      CHANNEL_GROUP: stable
+      CHANNEL_GROUP: candidate
       CLUSTER_PROFILE: rosa-hcp-pl
       QE_USAGE: rosa-hcp-private-critical-high-f3
       REGION: us-west-2
       RHCS_CLUSTER_NAME_SUFFIX: f3
       RHCS_URL: https://api.stage.openshift.com
+      VERSION: 4.22.0-rc.3
       WAIT_OPERATORS: "false"
     test:
     - ref: rhcs-e2e-tests


### PR DESCRIPTION
DO NOT MERGE, just triggering tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR creates a new E2E test configuration file for the terraform-provider-rhcs repository. The file defines a comprehensive suite of periodic CI/CD test jobs that validate the Terraform provider against Red Hat OpenShift Service on AWS (RHCS) clusters.

The configuration sets up 19 different E2E test jobs covering multiple RHCS deployment scenarios (STS-based, HCP-based, classic, upgrade paths, etc.) with staggered cron schedules to distribute test load. Notably, seven of these jobs are configured to run against **OCP 4.22.0-rc.3** using the `candidate` channel group:

- `rosa-sts-advanced-critical-high-f3`
- `rosa-sts-private-critical-high-f3`  
- `rosa-sts-shared-vpc-critical-high-f3`
- `rosa-sts-advanced-medium-low-f7`
- `rosa-hcp-advanced-critical-high-f3`
- `rosa-hcp-advanced-medium-low-f7`
- `rosa-hcp-private-critical-high-f3`

The remaining test jobs use the stable channel group and default to OCP 4.21. All tests report results to the `#tf-provider-qe-ci` Slack channel and use the `oex-aws-qe` cluster profile for execution. This prepares the terraform-provider-rhcs CI infrastructure for validating compatibility with OCP 4.22 release candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->