### PR TITLE
DPTP-4410: Argo ignore MachineSet MCO drift (AWS ami, GCP disk)

### DIFF
--- a/clusters/gitops/apps/app-cluster-appci.yaml
+++ b/clusters/gitops/apps/app-cluster-appci.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: app.ci
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
+      kind: MachineSet
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build01.yaml
+++ b/clusters/gitops/apps/app-cluster-build01.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build01
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build02.yaml
+++ b/clusters/gitops/apps/app-cluster-build02.yaml
@@ -9,7 +9,6 @@ spec:
   destination:
     name: build02
     namespace: openshift-gitops
-  # DPTP-4410: ignore GCP MachineSet boot disk image (MCO); Argo selfHeal must not revert it.
   ignoreDifferences:
     - group: machine.openshift.io
       kind: MachineSet

--- a/clusters/gitops/apps/app-cluster-build03.yaml
+++ b/clusters/gitops/apps/app-cluster-build03.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build03
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build04.yaml
+++ b/clusters/gitops/apps/app-cluster-build04.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build04
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.disks[]?.image
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build05.yaml
+++ b/clusters/gitops/apps/app-cluster-build05.yaml
@@ -9,7 +9,6 @@ spec:
   destination:
     name: build05
     namespace: openshift-gitops
-  # DPTP-4410: ignore AWS MachineSet AMI (MCO); Argo selfHeal must not revert it.
   ignoreDifferences:
     - group: machine.openshift.io
       kind: MachineSet

--- a/clusters/gitops/apps/app-cluster-build06.yaml
+++ b/clusters/gitops/apps/app-cluster-build06.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build06
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build07.yaml
+++ b/clusters/gitops/apps/app-cluster-build07.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build07
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build08.yaml
+++ b/clusters/gitops/apps/app-cluster-build08.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build08
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.disks[]?.image
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build09.yaml
+++ b/clusters/gitops/apps/app-cluster-build09.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build09
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build10.yaml
+++ b/clusters/gitops/apps/app-cluster-build10.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build10
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-build11.yaml
+++ b/clusters/gitops/apps/app-cluster-build11.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: build11
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      kind: MachineSet
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-core-ci.yaml
+++ b/clusters/gitops/apps/app-cluster-core-ci.yaml
@@ -9,6 +9,11 @@ spec:
   destination:
     name: core-ci
     namespace: openshift-gitops
+  ignoreDifferences:
+    - group: machine.openshift.io
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
+      kind: MachineSet
   project: default
   source:
     directory:

--- a/clusters/gitops/apps/app-cluster-hosted-mgmt.yaml
+++ b/clusters/gitops/apps/app-cluster-hosted-mgmt.yaml
@@ -19,6 +19,10 @@ spec:
         - /rules
       kind: ClusterRole
       name: ci-admins-aggregated
+    - group: machine.openshift.io
+      jqPathExpressions:
+        - .spec.template.spec.providerSpec.value.ami
+      kind: MachineSet
   project: default
   source:
     directory:


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR extends Argo CD's `ignoreDifferences` configuration across OpenShift CI infrastructure clusters to prevent sync drift alerts for MachineSet resources managed by the Machine Config Operator (MCO).

## Changes

The PR adds `ignoreDifferences` rules to 14 Argo CD Application manifests for CI clusters:

**AWS AMI changes** (ignored for AWS-based clusters):
- Configured across `app-cluster-appci`, `app-cluster-core-ci`, and multiple build clusters (`build01`, `build03`, `build06`, `build07`, `build09`, `build10`, `build11`)
- Ignores drift in `.spec.template.spec.providerSpec.value.ami` for `machine.openshift.io/MachineSet` resources
- Prevents Argo CD from flagging AMI updates that are rolled out by MCO

**GCP disk changes** (ignored for GCP-based clusters):
- Configured for build clusters `build04` and `build08`
- Ignores drift in `.spec.template.spec.providerSpec.value.disks[]?.image` for `machine.openshift.io/MachineSet` resources
- Allows GCP machine image updates controlled by MCO without triggering sync conflicts

**Hosted management cluster**:
- `app-cluster-hosted-mgmt` adds the AMI ignore rule while preserving its existing `ignoreDifferences` configuration for Hive and ClusterRole resources

This aligns Argo CD configuration to treat MCO-managed cloud provider resource updates as expected drift rather than configuration drift, reducing manual intervention and false sync alerts in the CI infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->