### PR TITLE
GCP-297: hypershift: add e2e-v2-gke periodic job for 4.23 and 5.0

### DIFF
--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-4.23__periodics.yaml
@@ -371,6 +371,16 @@ tests:
       LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
       TECH_PREVIEW_NO_UPGRADE: "true"
     workflow: hypershift-openstack-nested-conformance
+- as: e2e-v2-gke
+  capabilities:
+  - build-tmpfs
+  cron: 37 9,21 * * *
+  steps:
+    cluster_profile: hypershift-gcp
+    env:
+      GKE_REGION: us-central1
+      GKE_RELEASE_CHANNEL: stable
+    workflow: hypershift-gcp-gke-e2e-v2
 zz_generated_metadata:
   branch: release-4.23
   org: openshift

--- a/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0__periodics.yaml
+++ b/ci-operator/config/openshift/hypershift/openshift-hypershift-release-5.0__periodics.yaml
@@ -370,6 +370,16 @@ tests:
       LVM_OPERATOR_SUB_SOURCE: lvm-catalogsource
       TECH_PREVIEW_NO_UPGRADE: "true"
     workflow: hypershift-openstack-nested-conformance
+- as: e2e-v2-gke
+  capabilities:
+  - build-tmpfs
+  cron: 37 9,21 * * *
+  steps:
+    cluster_profile: hypershift-gcp
+    env:
+      GKE_REGION: us-central1
+      GKE_RELEASE_CHANNEL: stable
+    workflow: hypershift-gcp-gke-e2e-v2
 zz_generated_metadata:
   branch: release-5.0
   org: openshift

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.23-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.23-periodics.yaml
@@ -2238,3 +2238,87 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build07
+  cron: 37 9,21 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-4.23
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/build-tmpfs: build-tmpfs
+    ci-operator.openshift.io/cloud: hypershift-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: hypershift-gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "4.23"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-v2-gke
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-v2-gke
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-5.0-periodics.yaml
+++ b/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-5.0-periodics.yaml
@@ -2238,3 +2238,87 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cluster: build07
+  cron: 37 9,21 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: release-5.0
+    org: openshift
+    repo: hypershift
+  labels:
+    capability/build-tmpfs: build-tmpfs
+    ci-operator.openshift.io/cloud: hypershift-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: hypershift-gcp
+    ci-operator.openshift.io/variant: periodics
+    ci.openshift.io/generator: prowgen
+    job-release: "5.0"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-v2-gke
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=e2e-v2-gke
+      - --variant=periodics
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION
## Summary

- Adds `e2e-v2-gke` periodic job (cron `37 9,21 * * *`, twice daily) to `openshift-hypershift-release-4.23__periodics.yaml` and `openshift-hypershift-release-5.0__periodics.yaml`
- Uses `hypershift-gcp` cluster profile, `hypershift-gcp-gke-e2e-v2` workflow, with `GKE_REGION: us-central1` and `GKE_RELEASE_CHANNEL: stable`
- Follows the same pattern as the existing `e2e-aks` periodic (cron offset by 16 min to avoid overlap)
- After merge, `sippy-config-generator` and `auto-testgrid-generator` will auto-discover the jobs via `job-release` labels

The corresponding presubmit (`e2e-v2-gke`) was made required for merge in #78842 (merged May 12). This periodic enables nightly flake detection and Sippy/TestGrid dashboard visibility. Tracked in [GCP-297](https://redhat.atlassian.net/browse/GCP-297).

## Test plan

- [x] `make update` succeeds with no unexpected changes
- [x] Generated job names: `periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-v2-gke` and `periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-v2-gke`
- [x] Cron `37 9,21 * * *` present in generated Prow YAML
- [x] Only 4 files changed (2 config, 2 generated jobs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a new periodic CI job, e2e-v2-gke, to the OpenShift Hypershift CI configuration for release variants 4.23 and 5.0.

## Changes (practical impact)

- Adds a periodic ci-operator job entry in the openshift-hypershift release periodic manifests so Hypershift's GKE e2e-v2 tests will run automatically for those release branches.
- The job runs twice daily at 09:37 and 21:37 UTC (cron: `37 9,21 * * *`), offset by 16 minutes from the existing e2e-aks periodic to avoid overlap.
- Uses the `hypershift-gcp` cluster profile and the `hypershift-gcp-gke-e2e-v2` workflow and sets environment variables `GKE_REGION=us-central1` and `GKE_RELEASE_CHANNEL=stable`.
- Includes the `build-tmpfs` capability consistent with other hypershift periodic jobs.
- After merge, sippy-config-generator and auto-testgrid-generator will pick up the job via job-release labels so results appear in Sippy/TestGrid.

## Rationale / Purpose

Enable recurring GKE e2e-v2 runs for Hypershift to detect flakes and provide visibility in Sippy/TestGrid. This complements the presubmit e2e-v2-gke job that was made required in a prior merged PR.

## Test plan / Validation

- `make update` ran successfully with the expected generated Prow job names:
  - periodic-ci-openshift-hypershift-release-4.23-periodics-e2e-v2-gke
  - periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-v2-gke
- The generated Prow YAML contains the cron `37 9,21 * * *`.
- Changes are limited to 4 files (2 config manifests, 2 generated Prow job files).

## Metadata / Notes

- PR references Jira [GCP-297](https://redhat.atlassian.net/browse/GCP-297) (openshift-ci-robot flagged the Jira target version mismatch vs. target branch).
- Presubmit e2e-v2-gke was made required in PR #78842.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[GCP-297]: https://redhat.atlassian.net/browse/GCP-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ