### PR TITLE
Adding build12 into cluster pool

### DIFF
--- a/core-services/sanitize-prow-jobs/_clusters.yaml
+++ b/core-services/sanitize-prow-jobs/_clusters.yaml
@@ -67,6 +67,12 @@ stataws:
     - intranet
     - power-s2s-dns
     capacity: 75
+  - name: build12
+    blocked: false
+    capabilities:
+    - arm64
+    - intranet
+    capacity: 25
 gcp:
   - name: build02
     blocked: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Adding build12 cluster to OpenShift CI infrastructure

This PR adds a new build cluster, `build12`, to the OpenShift CI infrastructure's cluster pool configuration.

### What's changing

The `_clusters.yaml` file in `core-services/sanitize-prow-jobs/` is updated to include a new StatAWS (Amazon Web Services) build cluster available for running Prow CI jobs. The new cluster:
- **Capacity**: 25 concurrent build pods
- **Capabilities**: ARM64 architecture support and intranet-only job handling
- **Status**: Enabled (not blocked) and ready to accept workloads

### Impact

This expands the available build infrastructure for OpenShift CI, providing additional capacity for CI jobs that require ARM64 architecture or intranet connectivity. The cluster joins the existing StatAWS pool alongside build01, build03, build05-build07, build09-build11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->