### PR TITLE
ROSAENG-1115: fix the MC login to not use backplane plugin

### DIFF
--- a/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
+++ b/ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh
@@ -45,18 +45,36 @@ export OCM_ENV="${OCM_LOGIN_ENV}"
 export CLUSTER_ID
 export AWS_REGION="${LEASED_RESOURCE}"
 
-# Try to get manager cluster access via backplane
-log "Attempting manager cluster access via backplane..."
-if ocm backplane login "${CLUSTER_ID}" --manager --multi 2>&1; then
-  export MC_KUBECONFIG="${HOME}/.kube/config"
-  MC_SERVER=$(oc whoami --show-server 2>/dev/null || true)
-  if [[ -n "${MC_SERVER}" && "${MC_SERVER}" == *"backplane"* ]]; then
-    MANAGEMENT_CLUSTER_ID=$(echo "${MC_SERVER}" | sed 's|.*/cluster/||; s|/.*||')
-    export MANAGEMENT_CLUSTER_ID
-    log "Manager cluster access established: ${MANAGEMENT_CLUSTER_ID}"
+# Try to get management cluster access via OCM API
+log "Attempting management cluster access..."
+MC_NAME=$(ocm get /api/clusters_mgmt/v1/clusters/"${CLUSTER_ID}"/hypershift 2>/dev/null | jq -r '.management_cluster // empty')
+if [[ -n "${MC_NAME}" ]]; then
+  log "Management cluster name: ${MC_NAME}"
+  MANAGEMENT_CLUSTER_ID=$(ocm get /api/clusters_mgmt/v1/clusters --parameter search="name='${MC_NAME}'" --parameter size=1 2>/dev/null | jq -r '.items[0].id // empty')
+  if [[ -n "${MANAGEMENT_CLUSTER_ID}" ]]; then
+    MC_LISTENING=$(ocm get /api/clusters_mgmt/v1/clusters/"${MANAGEMENT_CLUSTER_ID}" 2>/dev/null | jq -r '.api.listening // empty')
+    if [[ "${MC_LISTENING}" == "external" ]]; then
+      log "Management cluster ${MANAGEMENT_CLUSTER_ID} API is external, fetching kubeconfig..."
+      MC_KUBECONFIG_FILE="${SHARED_DIR}/mc-kubeconfig"
+      set +x
+      ocm get /api/clusters_mgmt/v1/clusters/"${MANAGEMENT_CLUSTER_ID}"/credentials 2>/dev/null | jq -r '.kubeconfig' > "${MC_KUBECONFIG_FILE}"
+      set -x 2>/dev/null || true
+      if KUBECONFIG="${MC_KUBECONFIG_FILE}" oc whoami &>/dev/null; then
+        export MC_KUBECONFIG="${MC_KUBECONFIG_FILE}"
+        export MANAGEMENT_CLUSTER_ID
+        log "Management cluster access established: ${MANAGEMENT_CLUSTER_ID}"
+      else
+        log "WARNING: MC kubeconfig fetched but failed validation (oc whoami failed), skipping MC access"
+        rm -f "${MC_KUBECONFIG_FILE}"
+      fi
+    else
+      log "Management cluster ${MANAGEMENT_CLUSTER_ID} API is ${MC_LISTENING:-unknown}, skipping MC access"
+    fi
+  else
+    log "Could not resolve management cluster ID for ${MC_NAME}"
   fi
 else
-  log "WARNING: Backplane login failed (expected in CI without network access to MC)"
+  log "No management cluster found for cluster ${CLUSTER_ID} (not HCP or hypershift info unavailable)"
 fi
 
 # Run tests


### PR DESCRIPTION
backplane is not capable for testing for ci clusters.

try to use the kubeconfig directly 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Management Cluster Access for ROSA E2E Tests

This PR modifies the ROSA e2e CI step script to stop using the backplane plugin for management-cluster (MC) login and instead obtain MC credentials directly via the OCM API. The change lives in the CI step registry script used by ROSA e2e jobs (ci-operator/step-registry/rosa/e2e/test/rosa-e2e-test-commands.sh) and affects ROSA e2e jobs that include this step.

### What changed (practical behavior)
- Removed the backplane-based login and the prior logic that parsed `oc whoami --show-server` and relied on `${HOME}/.kube/config`.
- Uses the OCM "clusters_mgmt" API to:
  - Find the hypershift management cluster name for the test cluster (CLUSTER_ID).
  - Resolve the management cluster ID by name.
  - Check whether the management cluster API is externally accessible.
- When the management cluster is external:
  - Fetches the management cluster kubeconfig from the OCM credentials endpoint and writes it to ${SHARED_DIR}/mc-kubeconfig.
  - Sets KUBECONFIG to validate access with `oc whoami`.
  - On successful validation, exports MC_KUBECONFIG (pointing to ${SHARED_DIR}/mc-kubeconfig) and MANAGEMENT_CLUSTER_ID for downstream steps.
  - On validation failure, removes the fetched kubeconfig and skips exporting MC access.
- If the management cluster name/ID cannot be resolved or the API is not external, the script logs that it is skipping MC access and continues without failing the job.

### Why this matters
- Removes dependency on the backplane plugin which is not suitable for CI clusters.
- Provides a direct, API-driven method to obtain MC credentials suitable for CI, improving reliability for ROSA e2e jobs that need management-cluster access.
- Exports MC-related environment variables only after successful validation, and handles non-hypershift or non-external clusters by skipping MC access gracefully.

### Notable implementation details
- MC kubeconfig is now written to and exposed from ${SHARED_DIR}/mc-kubeconfig (exported as MC_KUBECONFIG only after validation).
- MANAGEMENT_CLUSTER_ID is exported only after resolving an external management cluster and successful access validation.
- The previous export of MC_KUBECONFIG="${HOME}/.kube/config" and backplane flow have been removed.

This change impacts all ROSA e2e test jobs that use the updated step-registry script by changing how management-cluster credentials are discovered and validated in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->