### PR TITLE
CNTRLPLANE-3380: Add rebasebot periodic for openshift/apiserver-network-proxy

### DIFF
--- a/ci-operator/config/openshift-eng/rebasebot/openshift-eng-rebasebot-main.yaml
+++ b/ci-operator/config/openshift-eng/rebasebot/openshift-eng-rebasebot-main.yaml
@@ -33,6 +33,35 @@ resources:
       memory: 200Mi
 test_binary_build_commands: make deps
 tests:
+- as: apiserver-network-proxy
+  cron: 0 12 * * Mon,Thu
+  steps:
+    test:
+    - as: apiserver-network-proxy
+      commands: |
+        rebasebot --source https://github.com/kubernetes-sigs/apiserver-network-proxy:master \
+                  --dest openshift/apiserver-network-proxy:main \
+                  --rebase openshift/apiserver-network-proxy:rebase-bot-main \
+                  --update-go-modules \
+                  --github-app-key /secrets/rebasebot/hypershift-rebase-bot-key \
+                  --github-cloner-key /secrets/rebasebot/hypershift-rebase-bot-key \
+                  --github-app-id 3706026 \
+                  --github-cloner-id 3706026 \
+                  --git-username hypershift-rebase-bot \
+                  --git-email hypershift-rebase-bot@redhat.com \
+                  --bot-emails hypershift-rebase-bot@redhat.com openshift-bot@redhat.com openshift-ci-robot@redhat.com \
+                  --tag-policy=strict
+      credentials:
+      - mount_path: /secrets/rebasebot
+        name: hypershift-rebasebot-credentials
+        namespace: test-credentials
+      from: rebasebot
+      resources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: 400m
+          memory: 1Gi
 - as: cloud-provider-aws
   cron: 0 12 * * Mon,Thu
   steps:

--- a/ci-operator/jobs/openshift-eng/rebasebot/openshift-eng-rebasebot-main-periodics.yaml
+++ b/ci-operator/jobs/openshift-eng/rebasebot/openshift-eng-rebasebot-main-periodics.yaml
@@ -1,6 +1,80 @@
 periodics:
 - agent: kubernetes
   cluster: build08
+  cron: 0 12 * * Mon,Thu
+  decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - Containerfile
+  extra_refs:
+  - base_ref: main
+    org: openshift-eng
+    repo: rebasebot
+    sparse_checkout_files:
+    - Containerfile
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-eng-rebasebot-main-apiserver-network-proxy
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --target=apiserver-network-proxy
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build08
   cron: 0 12 * * Wed
   decorate: true
   decoration_config:


### PR DESCRIPTION
## Summary
- Adds a rebasebot periodic job to automatically rebase `openshift/apiserver-network-proxy` onto upstream `kubernetes-sigs/apiserver-network-proxy:master`
- Runs Mon/Thu at 12:00 UTC using a new HyperShift Rebase Bot GitHub App (ID: 3706026)
- Uses a single GitHub App for both app and cloner roles (same-org pattern, like the autoscaling team)
- Credentials stored in Vault at `selfservice/hypershift-team/ops/rebase-bot`, synced to `hypershift-rebasebot-credentials` in `test-credentials`

## Test plan
- [x] Local dry run completed successfully — rebasebot correctly identified 2 carry commits and rebased onto upstream master
- [ ] Verify Vault secret has synced to `test-credentials` namespace on CI clusters
- [ ] After merge, confirm periodic job `periodic-ci-openshift-eng-rebasebot-main-apiserver-network-proxy` appears in Prow
- [ ] Verify first automated rebase PR is created on `openshift/apiserver-network-proxy`

/cc @openshift/hypershift-team

🤖 Generated with [Claude Code](https://claude.com/claude-code)