### PR TITLE
NO-JIRA: feat: add override plugin for edge-tooling

### DIFF
--- a/core-services/prow/02_config/openshift-eng/edge-tooling/_pluginconfig.yaml
+++ b/core-services/prow/02_config/openshift-eng/edge-tooling/_pluginconfig.yaml
@@ -13,6 +13,7 @@ plugins:
     - hold
     - label
     - lgtm
+    - override
     - trigger
     - verify-owners
     - wip


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR enables the Prow `override` plugin for the `openshift-eng/edge-tooling` repository by adding it to the plugin list in the repository's Prow configuration.

The `override` plugin is a Prow feature that allows authorized users to bypass certain status checks and proceed with pull request merges when needed. For the edge-tooling repository, this enables developers to override blocking checks in exceptional cases where necessary, improving operational flexibility for that project's CI/CD workflow.

The change is minimal—a single line addition to the plugin configuration file—but enables new functionality for the edge-tooling project's pull request handling within the OpenShift CI infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->