### PR TITLE
test: validate sparse checkout ci-operator fix

### DIFF
--- a/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift-eng/edge-tooling/openshift-eng-edge-tooling-main-presubmits.yaml
@@ -91,7 +91,7 @@ presubmits:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        image: quay.io/prucek/ci-operator:latest
         imagePullPolicy: Always
         name: ""
         ports:

--- a/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-main-presubmits.yaml
@@ -1216,7 +1216,7 @@ presubmits:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        image: quay.io/prucek/ci-operator:latest
         imagePullPolicy: Always
         name: ""
         ports:

--- a/ci-operator/jobs/openshift/installer/openshift-installer-main-presubmits.yaml
+++ b/ci-operator/jobs/openshift/installer/openshift-installer-main-presubmits.yaml
@@ -11299,7 +11299,7 @@ presubmits:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        image: quay.io/prucek/ci-operator:latest
         imagePullPolicy: Always
         name: ""
         ports:


### PR DESCRIPTION
## Summary
- Testing patched ci-operator image (`quay.io/prucek/ci-operator:latest`) that clears `SparseCheckoutFiles` in test pod clonerefs
- Overrides ci-operator image for `pull-ci-openshift-ci-tools-main-lint` and `pull-ci-openshift-installer-main-shellcheck` to validate the fix

## Test plan
- [ ] Rehearsal of `pull-ci-openshift-ci-tools-main-lint` passes (previously failed with `hack/lint.sh: No such file`)
- [ ] Rehearsal of `pull-ci-openshift-installer-main-shellcheck` passes

DO NOT MERGE — testing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)