### PR TITLE
bump AMD GPU operator versions to 1.4 and 1.5

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.16-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.16-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "4.16"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "4.16"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "4.16"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.17-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.17-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "4.17"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "4.17"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "4.17"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.18-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.18-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "4.18"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "4.18"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "4.18"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.19-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.19-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "4.19"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "4.19"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "4.19"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.20-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.20-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "4.20"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "4.20"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "4.20"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.21-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.21-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "4.21"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "4.21"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "4.21"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.22-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.22-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "4.22"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "4.22"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "4.22"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.23-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__4.23-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "4.23"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "4.23"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "4.23"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__5.0-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main__5.0-stable.yaml
@@ -25,20 +25,6 @@ resources:
       memory: 200Mi
 tests:
 - always_run: false
-  as: e2e-amd-ci-1-3-x
-  capabilities:
-  - intranet
-  restrict_network_access: false
-  steps:
-    cluster_profile: aws-edge-infra
-    env:
-      AMD_DRIVER_VERSION: 30.20.1
-      GPU_OPERATOR_VERSION: "1.3"
-      OCP_CLUSTER_VERSION: "5.0"
-      PCI_DEVICES: 0000:b3:00.0
-      SKIP_CLUSTER_DELETE: "false"
-    workflow: amd-gpu-operator-e2e
-- always_run: false
   as: e2e-amd-ci-1-4-x
   capabilities:
   - intranet
@@ -48,6 +34,20 @@ tests:
     env:
       AMD_DRIVER_VERSION: 30.20.1
       GPU_OPERATOR_VERSION: "1.4"
+      OCP_CLUSTER_VERSION: "5.0"
+      PCI_DEVICES: 0000:b3:00.0
+      SKIP_CLUSTER_DELETE: "false"
+    workflow: amd-gpu-operator-e2e
+- always_run: false
+  as: e2e-amd-ci-1-5-x
+  capabilities:
+  - intranet
+  restrict_network_access: false
+  steps:
+    cluster_profile: aws-edge-infra
+    env:
+      AMD_DRIVER_VERSION: 30.20.1
+      GPU_OPERATOR_VERSION: "1.5"
       OCP_CLUSTER_VERSION: "5.0"
       PCI_DEVICES: 0000:b3:00.0
       SKIP_CLUSTER_DELETE: "false"

--- a/ci-operator/jobs/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main-presubmits.yaml
+++ b/ci-operator/jobs/rh-ecosystem-edge/amd-ci/rh-ecosystem-edge-amd-ci-main-presubmits.yaml
@@ -6,92 +6,6 @@ presubmits:
     - ^main$
     - ^main-
     cluster: build10
-    context: ci/prow/4.16-stable-e2e-amd-ci-1-3-x
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      capability/intranet: intranet
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 4.16-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.16-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 4.16-stable-e2e-amd-ci-1-3-x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --lease-server-credentials-file=/etc/boskos/credentials
-        - --report-credentials-file=/etc/report/credentials
-        - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=4.16-stable
-        command:
-        - ci-operator
-        env:
-        - name: HTTP_SERVER_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        ports:
-        - containerPort: 8080
-          name: http
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /etc/boskos
-          name: boskos
-          readOnly: true
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
-          readOnly: true
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: boskos
-        secret:
-          items:
-          - key: credentials
-            path: credentials
-          secretName: boskos-credentials
-      - name: ci-pull-credentials
-        secret:
-          secretName: ci-pull-credentials
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.16-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
-    cluster: build10
     context: ci/prow/4.16-stable-e2e-amd-ci-1-4-x
     decorate: true
     decoration_config:
@@ -177,67 +91,8 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/4.16-stable-images
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      ci-operator.openshift.io/variant: 4.16-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.16-stable-images
-    rerun_command: /test 4.16-stable-images
-    run_if_changed: ^x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --variant=4.16-stable
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )4.16-stable-images,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
     cluster: build10
-    context: ci/prow/4.17-stable-e2e-amd-ci-1-3-x
+    context: ci/prow/4.16-stable-e2e-amd-ci-1-5-x
     decorate: true
     decoration_config:
       sparse_checkout_files:
@@ -246,11 +101,11 @@ presubmits:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 4.17-stable
+      ci-operator.openshift.io/variant: 4.16-stable
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.17-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 4.17-stable-e2e-amd-ci-1-3-x
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.16-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 4.16-stable-e2e-amd-ci-1-5-x
     spec:
       containers:
       - args:
@@ -259,8 +114,8 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=4.17-stable
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=4.16-stable
         command:
         - ci-operator
         env:
@@ -316,7 +171,66 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.17-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(4.16-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/4.16-stable-images
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      ci-operator.openshift.io/variant: 4.16-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.16-stable-images
+    rerun_command: /test 4.16-stable-images
+    run_if_changed: ^x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.16-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.16-stable-images,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -408,67 +322,8 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/4.17-stable-images
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      ci-operator.openshift.io/variant: 4.17-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.17-stable-images
-    rerun_command: /test 4.17-stable-images
-    run_if_changed: ^x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --variant=4.17-stable
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )4.17-stable-images,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
     cluster: build10
-    context: ci/prow/4.18-stable-e2e-amd-ci-1-3-x
+    context: ci/prow/4.17-stable-e2e-amd-ci-1-5-x
     decorate: true
     decoration_config:
       sparse_checkout_files:
@@ -477,11 +332,11 @@ presubmits:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 4.18-stable
+      ci-operator.openshift.io/variant: 4.17-stable
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.18-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 4.18-stable-e2e-amd-ci-1-3-x
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.17-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 4.17-stable-e2e-amd-ci-1-5-x
     spec:
       containers:
       - args:
@@ -490,8 +345,8 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=4.18-stable
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=4.17-stable
         command:
         - ci-operator
         env:
@@ -547,7 +402,66 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.18-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(4.17-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/4.17-stable-images
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      ci-operator.openshift.io/variant: 4.17-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.17-stable-images
+    rerun_command: /test 4.17-stable-images
+    run_if_changed: ^x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.17-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.17-stable-images,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -639,67 +553,8 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/4.18-stable-images
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      ci-operator.openshift.io/variant: 4.18-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.18-stable-images
-    rerun_command: /test 4.18-stable-images
-    run_if_changed: ^x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --variant=4.18-stable
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )4.18-stable-images,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
     cluster: build10
-    context: ci/prow/4.19-stable-e2e-amd-ci-1-3-x
+    context: ci/prow/4.18-stable-e2e-amd-ci-1-5-x
     decorate: true
     decoration_config:
       sparse_checkout_files:
@@ -708,11 +563,11 @@ presubmits:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 4.19-stable
+      ci-operator.openshift.io/variant: 4.18-stable
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.19-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 4.19-stable-e2e-amd-ci-1-3-x
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.18-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 4.18-stable-e2e-amd-ci-1-5-x
     spec:
       containers:
       - args:
@@ -721,8 +576,8 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=4.19-stable
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=4.18-stable
         command:
         - ci-operator
         env:
@@ -778,7 +633,66 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.19-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(4.18-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/4.18-stable-images
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      ci-operator.openshift.io/variant: 4.18-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.18-stable-images
+    rerun_command: /test 4.18-stable-images
+    run_if_changed: ^x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.18-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.18-stable-images,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -870,67 +784,8 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/4.19-stable-images
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      ci-operator.openshift.io/variant: 4.19-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.19-stable-images
-    rerun_command: /test 4.19-stable-images
-    run_if_changed: ^x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --variant=4.19-stable
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )4.19-stable-images,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
     cluster: build10
-    context: ci/prow/4.20-stable-e2e-amd-ci-1-3-x
+    context: ci/prow/4.19-stable-e2e-amd-ci-1-5-x
     decorate: true
     decoration_config:
       sparse_checkout_files:
@@ -939,11 +794,11 @@ presubmits:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 4.20-stable
+      ci-operator.openshift.io/variant: 4.19-stable
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.20-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 4.20-stable-e2e-amd-ci-1-3-x
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.19-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 4.19-stable-e2e-amd-ci-1-5-x
     spec:
       containers:
       - args:
@@ -952,8 +807,8 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=4.20-stable
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=4.19-stable
         command:
         - ci-operator
         env:
@@ -1009,7 +864,66 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.20-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(4.19-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/4.19-stable-images
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      ci-operator.openshift.io/variant: 4.19-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.19-stable-images
+    rerun_command: /test 4.19-stable-images
+    run_if_changed: ^x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.19-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.19-stable-images,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -1101,67 +1015,8 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/4.20-stable-images
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      ci-operator.openshift.io/variant: 4.20-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.20-stable-images
-    rerun_command: /test 4.20-stable-images
-    run_if_changed: ^x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --variant=4.20-stable
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )4.20-stable-images,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
     cluster: build10
-    context: ci/prow/4.21-stable-e2e-amd-ci-1-3-x
+    context: ci/prow/4.20-stable-e2e-amd-ci-1-5-x
     decorate: true
     decoration_config:
       sparse_checkout_files:
@@ -1170,11 +1025,11 @@ presubmits:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 4.21-stable
+      ci-operator.openshift.io/variant: 4.20-stable
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.21-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 4.21-stable-e2e-amd-ci-1-3-x
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.20-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 4.20-stable-e2e-amd-ci-1-5-x
     spec:
       containers:
       - args:
@@ -1183,8 +1038,8 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=4.21-stable
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=4.20-stable
         command:
         - ci-operator
         env:
@@ -1240,7 +1095,66 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.21-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(4.20-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/4.20-stable-images
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      ci-operator.openshift.io/variant: 4.20-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.20-stable-images
+    rerun_command: /test 4.20-stable-images
+    run_if_changed: ^x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.20-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.20-stable-images,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -1332,67 +1246,8 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/4.21-stable-images
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      ci-operator.openshift.io/variant: 4.21-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.21-stable-images
-    rerun_command: /test 4.21-stable-images
-    run_if_changed: ^x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --variant=4.21-stable
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )4.21-stable-images,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
     cluster: build10
-    context: ci/prow/4.22-stable-e2e-amd-ci-1-3-x
+    context: ci/prow/4.21-stable-e2e-amd-ci-1-5-x
     decorate: true
     decoration_config:
       sparse_checkout_files:
@@ -1401,11 +1256,11 @@ presubmits:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 4.22-stable
+      ci-operator.openshift.io/variant: 4.21-stable
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.22-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 4.22-stable-e2e-amd-ci-1-3-x
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.21-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 4.21-stable-e2e-amd-ci-1-5-x
     spec:
       containers:
       - args:
@@ -1414,8 +1269,8 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=4.22-stable
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=4.21-stable
         command:
         - ci-operator
         env:
@@ -1471,7 +1326,66 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.22-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(4.21-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/4.21-stable-images
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      ci-operator.openshift.io/variant: 4.21-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.21-stable-images
+    rerun_command: /test 4.21-stable-images
+    run_if_changed: ^x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.21-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.21-stable-images,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -1563,67 +1477,8 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/4.22-stable-images
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      ci-operator.openshift.io/variant: 4.22-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.22-stable-images
-    rerun_command: /test 4.22-stable-images
-    run_if_changed: ^x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --variant=4.22-stable
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )4.22-stable-images,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
     cluster: build10
-    context: ci/prow/4.23-stable-e2e-amd-ci-1-3-x
+    context: ci/prow/4.22-stable-e2e-amd-ci-1-5-x
     decorate: true
     decoration_config:
       sparse_checkout_files:
@@ -1632,11 +1487,11 @@ presubmits:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 4.23-stable
+      ci-operator.openshift.io/variant: 4.22-stable
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.23-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 4.23-stable-e2e-amd-ci-1-3-x
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.22-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 4.22-stable-e2e-amd-ci-1-5-x
     spec:
       containers:
       - args:
@@ -1645,8 +1500,8 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=4.23-stable
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=4.22-stable
         command:
         - ci-operator
         env:
@@ -1702,7 +1557,66 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(4.23-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(4.22-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/4.22-stable-images
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      ci-operator.openshift.io/variant: 4.22-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.22-stable-images
+    rerun_command: /test 4.22-stable-images
+    run_if_changed: ^x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.22-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.22-stable-images,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -1794,67 +1708,8 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: build07
-    context: ci/prow/4.23-stable-images
-    decorate: true
-    decoration_config:
-      sparse_checkout_files:
-      - Containerfile
-    labels:
-      ci-operator.openshift.io/variant: 4.23-stable
-      ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.23-stable-images
-    rerun_command: /test 4.23-stable-images
-    run_if_changed: ^x
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=[images]
-        - --variant=4.23-stable
-        command:
-        - ci-operator
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /secrets/manifest-tool
-          name: manifest-tool-local-pusher
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: manifest-tool-local-pusher
-        secret:
-          secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )4.23-stable-images,?($|\s.*)
-  - agent: kubernetes
-    always_run: false
-    branches:
-    - ^main$
-    - ^main-
     cluster: build10
-    context: ci/prow/5.0-stable-e2e-amd-ci-1-3-x
+    context: ci/prow/4.23-stable-e2e-amd-ci-1-5-x
     decorate: true
     decoration_config:
       sparse_checkout_files:
@@ -1863,11 +1718,11 @@ presubmits:
       capability/intranet: intranet
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
-      ci-operator.openshift.io/variant: 5.0-stable
+      ci-operator.openshift.io/variant: 4.23-stable
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-rh-ecosystem-edge-amd-ci-main-5.0-stable-e2e-amd-ci-1-3-x
-    rerun_command: /test 5.0-stable-e2e-amd-ci-1-3-x
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.23-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 4.23-stable-e2e-amd-ci-1-5-x
     spec:
       containers:
       - args:
@@ -1876,8 +1731,8 @@ presubmits:
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/secrets/ci-pull-credentials
-        - --target=e2e-amd-ci-1-3-x
-        - --variant=5.0-stable
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=4.23-stable
         command:
         - ci-operator
         env:
@@ -1933,7 +1788,66 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )(5.0-stable-e2e-amd-ci-1-3-x|remaining-required),?($|\s.*)
+    trigger: (?m)^/test( | .* )(4.23-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build07
+    context: ci/prow/4.23-stable-images
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      ci-operator.openshift.io/variant: 4.23-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-4.23-stable-images
+    rerun_command: /test 4.23-stable-images
+    run_if_changed: ^x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=[images]
+        - --variant=4.23-stable
+        command:
+        - ci-operator
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )4.23-stable-images,?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:
@@ -2020,6 +1934,92 @@ presubmits:
         secret:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )(5.0-stable-e2e-amd-ci-1-4-x|remaining-required),?($|\s.*)
+  - agent: kubernetes
+    always_run: false
+    branches:
+    - ^main$
+    - ^main-
+    cluster: build10
+    context: ci/prow/5.0-stable-e2e-amd-ci-1-5-x
+    decorate: true
+    decoration_config:
+      sparse_checkout_files:
+      - Containerfile
+    labels:
+      capability/intranet: intranet
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws-edge-infra
+      ci-operator.openshift.io/variant: 5.0-stable
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-rh-ecosystem-edge-amd-ci-main-5.0-stable-e2e-amd-ci-1-5-x
+    rerun_command: /test 5.0-stable-e2e-amd-ci-1-5-x
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=e2e-amd-ci-1-5-x
+        - --variant=5.0-stable
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )(5.0-stable-e2e-amd-ci-1-5-x|remaining-required),?($|\s.*)
   - agent: kubernetes
     always_run: false
     branches:


### PR DESCRIPTION
Update all variant configs to test GPU operator 1.4 and 1.5 instead of 1.3 and 1.4.


/cc @ggordaniRed 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the CI operator configuration for the AMD CI edge repository to test GPU operator versions 1.4 and 1.5, removing support for version 1.3. The changes ensure consistent testing across all OpenShift release branches.

## Changes Made

**Affected Repository:** rh-ecosystem-edge/amd-ci CI configuration  
**Files Modified:** 9 CI configuration files for OCP versions 4.16, 4.17, 4.18, 4.19, 4.20, 4.21, 4.22, 4.23, and 5.0 stable branches

**Configuration Updates:**
- Removed the `e2e-amd-ci-1-3-x` test variant from all branch configurations
- Updated `e2e-amd-ci-1-4-x` test entries to explicitly set `GPU_OPERATOR_VERSION: "1.4"` with required environment variables
- Added new `e2e-amd-ci-1-5-x` test entries to test GPU operator version 1.5 across all stable branches
- Both updated test variants maintain the `amd-gpu-operator-e2e` workflow and `aws-edge-infra` cluster profile configuration
- All changes maintain the same intranet capability and network access settings

The modifications ensure that AMD GPU operator CI testing progresses to newer versions (1.4 and 1.5) across all supported OpenShift release branches, with consistent environment configurations for reproducible testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->