### PR TITLE
test pr chnages

### DIFF
--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-nightly-4.20.yaml
@@ -101,8 +101,7 @@ tests:
     cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
-      COMPUTE_NODE_REPLICAS: "2"
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-nightly-4.20.yaml
@@ -89,7 +89,7 @@ tests:
 - as: ocp-e2e-upgrade-gcp-ovn-multi-a-a
   interval: 72h
   steps:
-    cluster_profile: gcp-arm64
+    cluster_profile: openshift-org-gcp
     env:
       COMPUTE_NODE_TYPE: t2a-standard-4
       OCP_ARCH: arm64
@@ -98,10 +98,11 @@ tests:
 - as: ocp-e2e-upgrade-gcp-ovn-multi-x-ax
   interval: 72h
   steps:
-    cluster_profile: gcp-arm64
+    cluster_profile: openshift-org-gcp
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
+      COMPUTE_NODE_REPLICAS: "2"
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous

--- a/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-nightly-4.20.yaml
+++ b/ci-operator/config/openshift/multiarch/openshift-multiarch-main__nightly-4.21-upgrade-from-nightly-4.20.yaml
@@ -89,7 +89,7 @@ tests:
 - as: ocp-e2e-upgrade-gcp-ovn-multi-a-a
   interval: 72h
   steps:
-    cluster_profile: openshift-org-gcp
+    cluster_profile: gcp-arm64
     env:
       COMPUTE_NODE_TYPE: t2a-standard-4
       OCP_ARCH: arm64
@@ -98,11 +98,10 @@ tests:
 - as: ocp-e2e-upgrade-gcp-ovn-multi-x-ax
   interval: 72h
   steps:
-    cluster_profile: openshift-org-gcp
+    cluster_profile: gcp-arm64
     env:
       ADDITIONAL_WORKER_ARCHITECTURE: aarch64
-      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-2
-      COMPUTE_NODE_REPLICAS: "2"
+      ADDITIONAL_WORKER_VM_TYPE: t2a-standard-4
       OCP_ARCH: amd64
       TEST_SUITE: upgrade-conformance
     workflow: openshift-upgrade-gcp-heterogeneous
@@ -133,8 +132,6 @@ tests:
       USE_EXTERNAL_DNS: "true"
     workflow: openshift-e2e-libvirt-vpn
 - as: ocp-ovn-remote-s2s-libvirt-multi-p-p
-  capabilities:
-  - power-s2s-dns
   cron: 0 5 * * 1-4
   steps:
     cluster_profile: libvirt-ppc64le-s2s
@@ -145,6 +142,7 @@ tests:
       BRANCH: "4.19"
       ETCD_DISK_SPEED: slow
       TEST_TYPE: upgrade
+      USE_EXTERNAL_DNS: "true"
     workflow: openshift-e2e-libvirt-upi
 zz_generated_metadata:
   branch: main

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -10181,7 +10181,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
@@ -10264,7 +10264,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
@@ -11598,7 +11598,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
@@ -11681,7 +11681,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
@@ -14012,7 +14012,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -14095,7 +14095,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -15429,7 +15429,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -15512,7 +15512,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -16680,7 +16680,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.15-upgrade-from-nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -16763,7 +16763,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.15-upgrade-from-nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -17346,7 +17346,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.15-upgrade-from-stable-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -17429,7 +17429,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.15-upgrade-from-stable-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -18424,7 +18424,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -18507,7 +18507,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -18745,6 +18745,90 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build01
+  cron: 0 0 2 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    ci-operator.openshift.io/variant: nightly-4.16
+    ci.openshift.io/generator: prowgen
+    job-release: "4.16"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.16-ocp-e2e-ovn-agent-remote-libvirt-s390x
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-e2e-ovn-agent-remote-libvirt-s390x
+      - --variant=nightly-4.16
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build11
   cron: 0 0 2 2 *
   decorate: true
@@ -18755,7 +18839,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -18840,8 +18923,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-3
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
+    ci-operator.openshift.io/cloud: powervs-4
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-4
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -18913,7 +18996,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 12 * * 5
   decorate: true
   decoration_config:
@@ -18923,9 +19006,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -19091,7 +19174,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -19414,7 +19496,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 30 1 *
   decorate: true
   decoration_config:
@@ -19424,9 +19506,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -19508,7 +19590,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -19925,7 +20006,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20008,7 +20089,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20080,7 +20161,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 16 * * 5
   decorate: true
   decoration_config:
@@ -20090,9 +20171,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20174,7 +20255,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -20248,7 +20328,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 26 1 *
   decorate: true
   decoration_config:
@@ -20258,9 +20338,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20415,7 +20495,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 28 1 *
   decorate: true
   decoration_config:
@@ -20425,9 +20505,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20509,7 +20589,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -20666,7 +20745,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 29 1 *
   decorate: true
   decoration_config:
@@ -20676,9 +20755,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -21010,7 +21089,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -21093,7 +21172,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -21593,7 +21672,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-stable-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -21676,7 +21755,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-stable-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -22672,7 +22751,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -22755,7 +22834,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -22838,7 +22917,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -23076,7 +23155,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 13 2 *
   decorate: true
   decoration_config:
@@ -23086,9 +23165,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -23170,7 +23249,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -23412,7 +23490,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 5 2 *
   decorate: true
   decoration_config:
@@ -23422,9 +23500,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -23496,7 +23574,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 18 * * 5
   decorate: true
   decoration_config:
@@ -23590,7 +23668,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -23674,7 +23751,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -23997,7 +24073,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 0 8 2 *
   decorate: true
   decoration_config:
@@ -24091,7 +24167,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -24508,7 +24583,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -24591,7 +24666,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -24663,7 +24738,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 22 * * 5
   decorate: true
   decoration_config:
@@ -24757,7 +24832,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -24774,6 +24848,174 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=ocp-fips-ovn-remote-s2s-libvirt-multi-p-p
+      - --variant=nightly-4.17
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 0 4 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    ci-operator.openshift.io/variant: nightly-4.17
+    ci.openshift.io/generator: prowgen
+    job-release: "4.17"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-multi-s390x
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-s390x
+      - --variant=nightly-4.17
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 0 5 2 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    ci-operator.openshift.io/variant: nightly-4.17
+    ci.openshift.io/generator: prowgen
+    job-release: "4.17"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-multi-z-z
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-z-z
       - --variant=nightly-4.17
       command:
       - ci-operator
@@ -24914,7 +25156,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 0 11 2 *
   decorate: true
   decoration_config:
@@ -25008,7 +25250,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -25165,7 +25406,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 0 12 2 *
   decorate: true
   decoration_config:
@@ -25509,7 +25750,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -25592,7 +25833,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -25664,7 +25905,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 20 * * 5
   decorate: true
   decoration_config:
@@ -25758,7 +25999,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-nightly-4.16
@@ -26092,7 +26332,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-stable-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -26175,7 +26415,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-stable-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -27337,7 +27577,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -27420,7 +27660,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -27503,7 +27743,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -27741,7 +27981,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 20 * * 0
   decorate: true
   decoration_config:
@@ -27751,9 +27991,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -27835,7 +28075,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -27920,8 +28159,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-3
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
+    ci-operator.openshift.io/cloud: powervs-7
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-7
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -28077,7 +28316,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 18 * * 2,4
   decorate: true
   decoration_config:
@@ -28087,9 +28326,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -28161,7 +28400,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 18 * * 1,3
   decorate: true
   decoration_config:
@@ -28255,7 +28494,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -28339,7 +28577,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -28662,7 +28899,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 18 * * 6
   decorate: true
   decoration_config:
@@ -28756,7 +28993,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -29173,7 +29409,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -29256,7 +29492,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -29328,7 +29564,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 19 * * 6
   decorate: true
   decoration_config:
@@ -29422,7 +29658,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -29439,6 +29674,174 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=ocp-fips-ovn-remote-s2s-libvirt-multi-p-p
+      - --variant=nightly-4.18
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 19 * * 1,3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    ci-operator.openshift.io/variant: nightly-4.18
+    ci.openshift.io/generator: prowgen
+    job-release: "4.18"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.18-ocp-heavy-build-ovn-remote-libvirt-multi-s390x
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-s390x
+      - --variant=nightly-4.18
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 19 * * 2,4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    ci-operator.openshift.io/variant: nightly-4.18
+    ci.openshift.io/generator: prowgen
+    job-release: "4.18"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.18-ocp-heavy-build-ovn-remote-libvirt-multi-z-z
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-z-z
       - --variant=nightly-4.18
       command:
       - ci-operator
@@ -29579,7 +29982,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 18 * * 0
   decorate: true
   decoration_config:
@@ -29673,7 +30076,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -29830,7 +30232,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 19 * * 0
   decorate: true
   decoration_config:
@@ -30174,7 +30576,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -30257,7 +30659,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -30329,7 +30731,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 20 * * 1-4
   decorate: true
   decoration_config:
@@ -30423,7 +30825,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-nightly-4.17
@@ -30757,7 +31158,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-stable-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -30840,7 +31241,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-stable-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -32075,6 +32476,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32082,10 +32484,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32158,6 +32559,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32165,10 +32567,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32241,6 +32642,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32248,10 +32650,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32489,7 +32890,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 23 * * 0
   decorate: true
   decoration_config:
@@ -32499,9 +32900,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32573,6 +32974,90 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  cluster: build01
+  cron: 0 23 * * 0
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    ci-operator.openshift.io/variant: nightly-4.19
+    ci.openshift.io/generator: prowgen
+    job-release: "4.19"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.19-ocp-e2e-ovn-agent-remote-libvirt-s390x
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-e2e-ovn-agent-remote-libvirt-s390x
+      - --variant=nightly-4.19
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cluster: build11
   cron: 0 23 * * 0
   decorate: true
@@ -32583,7 +33068,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -32658,7 +33142,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 15 * * *
+  cron: 0 23 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32668,8 +33152,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-3
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
+    ci-operator.openshift.io/cloud: powervs-7
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-7
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32825,7 +33309,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 21 * * 2,4
   decorate: true
   decoration_config:
@@ -32835,9 +33319,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32909,7 +33393,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 21 * * 1,3
   decorate: true
   decoration_config:
@@ -33003,7 +33487,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -33087,7 +33570,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -33410,7 +33892,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 21 * * 6
   decorate: true
   decoration_config:
@@ -33504,7 +33986,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -34004,7 +34485,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -34087,7 +34568,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -34159,7 +34640,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 22 * * 6
   decorate: true
   decoration_config:
@@ -34253,7 +34734,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -34270,6 +34750,174 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=ocp-fips-ovn-remote-s2s-libvirt-multi-p-p
+      - --variant=nightly-4.19
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 22 * * 1,3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    ci-operator.openshift.io/variant: nightly-4.19
+    ci.openshift.io/generator: prowgen
+    job-release: "4.19"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.19-ocp-heavy-build-ovn-remote-libvirt-multi-s390x
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-s390x
+      - --variant=nightly-4.19
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 22 * * 2,4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    ci-operator.openshift.io/variant: nightly-4.19
+    ci.openshift.io/generator: prowgen
+    job-release: "4.19"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.19-ocp-heavy-build-ovn-remote-libvirt-multi-z-z
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-z-z
       - --variant=nightly-4.19
       command:
       - ci-operator
@@ -34410,7 +35058,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 21 * * 0
   decorate: true
   decoration_config:
@@ -34504,7 +35152,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -34661,7 +35308,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 22 * * 0
   decorate: true
   decoration_config:
@@ -35005,7 +35652,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -35088,7 +35735,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -35160,7 +35807,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 23 * * 1-4
   decorate: true
   decoration_config:
@@ -35254,7 +35901,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-nightly-4.18
@@ -35588,7 +36234,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-stable-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -35671,7 +36317,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-stable-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -37075,6 +37721,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37082,10 +37729,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 186h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37168,7 +37814,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37241,6 +37887,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37248,10 +37895,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37324,6 +37970,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37331,10 +37978,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 192h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37417,7 +38063,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37655,7 +38301,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 2 * * 0
   decorate: true
   decoration_config:
@@ -37665,9 +38311,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37749,7 +38395,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -37834,8 +38479,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-6
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
+    ci-operator.openshift.io/cloud: powervs-8
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37991,7 +38636,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 * * 2,4
   decorate: true
   decoration_config:
@@ -38001,9 +38646,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-1
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -38075,7 +38720,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 0 * * 1,3
   decorate: true
   decoration_config:
@@ -38169,7 +38814,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -38253,7 +38897,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -38661,7 +39304,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 0 * * 6
   decorate: true
   decoration_config:
@@ -38755,7 +39398,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -39255,7 +39897,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -39338,7 +39980,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -39410,7 +40052,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 1 * * 6
   decorate: true
   decoration_config:
@@ -39504,7 +40146,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -39521,6 +40162,174 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=ocp-fips-ovn-remote-s2s-libvirt-multi-p-p
+      - --variant=nightly-4.20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 1 * * 1,3
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    ci-operator.openshift.io/variant: nightly-4.20
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-heavy-build-ovn-remote-libvirt-multi-s390x
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-s390x
+      - --variant=nightly-4.20
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: credentials
+          path: credentials
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: build09
+  cron: 0 1 * * 2,4
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: main
+    org: openshift
+    repo: multiarch
+  labels:
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    ci-operator.openshift.io/variant: nightly-4.20
+    ci.openshift.io/generator: prowgen
+    job-release: "4.20"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-heavy-build-ovn-remote-libvirt-multi-z-z
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-credentials-file=/etc/boskos/credentials
+      - --report-credentials-file=/etc/report/credentials
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-z-z
       - --variant=nightly-4.20
       command:
       - ci-operator
@@ -39661,7 +40470,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 0 * * 0
   decorate: true
   decoration_config:
@@ -39755,7 +40564,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -39912,7 +40720,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 1 * * 0
   decorate: true
   decoration_config:
@@ -40256,7 +41064,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -40339,7 +41147,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -40411,7 +41219,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 2 * * 1-4
   decorate: true
   decoration_config:
@@ -40505,7 +41313,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-nightly-4.19
@@ -40922,7 +41729,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-stable-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -41005,7 +41812,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-stable-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -42409,6 +43216,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -42416,10 +43224,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 204h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -42502,7 +43309,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -42575,6 +43382,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -42582,10 +43390,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 216h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -42658,6 +43465,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -42665,10 +43473,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 210h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -42751,7 +43558,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -42989,7 +43796,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 5 * * 0
   decorate: true
   decoration_config:
@@ -42999,9 +43806,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43083,7 +43890,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -43158,7 +43964,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 0 * * *
+  cron: 0 1 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -43253,8 +44059,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-6
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
+    ci-operator.openshift.io/cloud: powervs-8
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43410,7 +44216,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 3 * * 6
   decorate: true
   decoration_config:
@@ -43420,9 +44226,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43494,7 +44300,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 4 * * 6
   decorate: true
   decoration_config:
@@ -43588,7 +44394,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -43672,7 +44477,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -44080,7 +44884,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 4 * * 1-4
   decorate: true
   decoration_config:
@@ -44174,7 +44978,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -44674,7 +45477,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -44757,7 +45560,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -44829,7 +45632,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 3 * * 1-4
   decorate: true
   decoration_config:
@@ -44923,7 +45726,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -45080,7 +45882,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 3 * * 0
   decorate: true
   decoration_config:
@@ -45174,7 +45976,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -45331,7 +46132,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 4 * * 0
   decorate: true
   decoration_config:
@@ -45675,7 +46476,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -45758,7 +46559,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -45830,7 +46631,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 5 * * 1-4
   decorate: true
   decoration_config:
@@ -45924,7 +46725,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-nightly-4.20
@@ -46341,7 +47141,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-stable-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -46424,7 +47224,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-stable-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -47828,6 +48628,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -47835,10 +48636,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -47918,10 +48718,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 180h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -47994,6 +48794,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -48001,10 +48802,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48077,6 +48877,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -48084,10 +48885,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 192h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48167,10 +48967,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 174h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48408,7 +49208,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 8 * * 0
   decorate: true
   decoration_config:
@@ -48418,9 +49218,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48502,7 +49302,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -48672,8 +49471,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-6
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
+    ci-operator.openshift.io/cloud: powervs-8
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48829,7 +49628,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 6 * * 6
   decorate: true
   decoration_config:
@@ -48839,9 +49638,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48913,7 +49712,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 7 * * 6
   decorate: true
   decoration_config:
@@ -49007,7 +49806,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -49091,7 +49889,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -49165,7 +49962,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 10 * * 1-4
   decorate: true
   decoration_config:
@@ -49259,7 +50056,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -49501,7 +50297,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 9 * * 1-4
   decorate: true
   decoration_config:
@@ -49595,7 +50391,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -49835,7 +50630,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 7 * * 1-4
   decorate: true
   decoration_config:
@@ -49929,7 +50724,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -50013,7 +50807,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -50510,10 +51303,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 186h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -50593,10 +51386,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 204h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -50668,7 +51461,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 6 * * 1-4
   decorate: true
   decoration_config:
@@ -50762,7 +51555,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -50919,7 +51711,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 6 * * 0
   decorate: true
   decoration_config:
@@ -51013,7 +51805,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -51170,7 +51961,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 7 * * 0
   decorate: true
   decoration_config:
@@ -51514,7 +52305,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22-upgrade-from-nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -51597,7 +52388,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22-upgrade-from-nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -51669,7 +52460,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 8 * * 1-4
   decorate: true
   decoration_config:
@@ -52180,7 +52971,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22-upgrade-from-stable-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -52263,7 +53054,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.22-upgrade-from-stable-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -53667,6 +54458,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -53674,10 +54466,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 210h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -53760,7 +54551,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -53833,6 +54624,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -53840,10 +54632,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 186h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -53916,6 +54707,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -53923,10 +54715,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54006,10 +54797,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 216h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54247,7 +55038,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 7 4 *
   decorate: true
   decoration_config:
@@ -54257,9 +55048,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54341,7 +55132,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -54416,7 +55206,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 8 * * *
+  cron: 0 4 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -54511,8 +55301,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-3
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
+    ci-operator.openshift.io/cloud: powervs-8
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54668,7 +55458,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 9 4 *
   decorate: true
   decoration_config:
@@ -54678,9 +55468,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54752,7 +55542,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 31 3 *
   decorate: true
   decoration_config:
@@ -54762,9 +55552,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54846,7 +55636,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -54930,7 +55719,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -55172,7 +55960,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build09
   cron: 0 0 8 4 *
   decorate: true
   decoration_config:
@@ -55266,7 +56054,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -55506,7 +56293,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 4 4 *
   decorate: true
   decoration_config:
@@ -55516,9 +56303,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -55600,7 +56387,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -55684,7 +56470,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -56181,10 +56966,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 174h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -56264,10 +57049,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 192h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -56339,7 +57124,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 5 4 *
   decorate: true
   decoration_config:
@@ -56349,9 +57134,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -56433,7 +57218,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -56590,7 +57374,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 2 4 *
   decorate: true
   decoration_config:
@@ -56600,9 +57384,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -56684,7 +57468,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -56841,7 +57624,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 0 3 4 *
   decorate: true
   decoration_config:
@@ -56851,9 +57634,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57185,7 +57968,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57268,7 +58051,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57851,7 +58634,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57934,7 +58717,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-4.23-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -60848,6 +61631,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -60855,10 +61639,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -60938,10 +61721,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 210h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61014,6 +61797,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61021,10 +61805,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61097,6 +61880,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
+  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61104,10 +61888,9 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61187,10 +61970,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 204h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61428,7 +62211,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 8 * * 0
   decorate: true
   decoration_config:
@@ -61438,9 +62221,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61522,7 +62305,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -61597,7 +62379,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 12 * * *
+  cron: 0 4 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61692,8 +62474,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-6
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
+    ci-operator.openshift.io/cloud: powervs-8
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61849,7 +62631,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 6 * * 6
   decorate: true
   decoration_config:
@@ -61859,9 +62641,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61933,7 +62715,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 7 * * 6
   decorate: true
   decoration_config:
@@ -61943,9 +62725,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62027,7 +62809,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -62111,7 +62892,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -62519,7 +63299,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 7 * * 1-4
   decorate: true
   decoration_config:
@@ -62529,9 +63309,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62613,7 +63393,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -62697,7 +63476,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -63194,10 +63972,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 216h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -63277,10 +64055,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 180h
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -63352,7 +64130,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 6 * * 1-4
   decorate: true
   decoration_config:
@@ -63362,9 +64140,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -63446,7 +64224,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -63603,7 +64380,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 6 * * 0
   decorate: true
   decoration_config:
@@ -63613,9 +64390,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -63697,7 +64474,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -63854,7 +64630,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 7 * * 0
   decorate: true
   decoration_config:
@@ -63864,9 +64640,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64198,7 +64974,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64281,7 +65057,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64353,7 +65129,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build12
+  cluster: build01
   cron: 0 8 * * 1-4
   decorate: true
   decoration_config:
@@ -64363,9 +65139,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
+    capability/sshd-bastion: sshd-bastion
+    ci-operator.openshift.io/cloud: libvirt-s390x-2
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64864,7 +65640,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64947,7 +65723,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
+    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -45924,7 +45924,6 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-nightly-4.20

--- a/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
+++ b/ci-operator/jobs/openshift/multiarch/openshift-multiarch-main-periodics.yaml
@@ -10181,7 +10181,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
@@ -10264,7 +10264,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
@@ -11598,7 +11598,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
@@ -11681,7 +11681,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.14"
@@ -14012,7 +14012,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -14095,7 +14095,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -15429,7 +15429,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -15512,7 +15512,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -16680,7 +16680,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.15-upgrade-from-nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -16763,7 +16763,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.15-upgrade-from-nightly-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -17346,7 +17346,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.15-upgrade-from-stable-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -17429,7 +17429,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.15-upgrade-from-stable-4.14
     ci.openshift.io/generator: prowgen
     job-release: "4.15"
@@ -18424,7 +18424,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -18507,7 +18507,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -18745,90 +18745,6 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
-  cron: 0 0 2 2 *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
-    ci-operator.openshift.io/variant: nightly-4.16
-    ci.openshift.io/generator: prowgen
-    job-release: "4.16"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.16-ocp-e2e-ovn-agent-remote-libvirt-s390x
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-agent-remote-libvirt-s390x
-      - --variant=nightly-4.16
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
   cluster: build11
   cron: 0 0 2 2 *
   decorate: true
@@ -18839,6 +18755,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -18923,8 +18840,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-4
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-4
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -18996,7 +18913,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 12 * * 5
   decorate: true
   decoration_config:
@@ -19006,9 +18923,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -19174,6 +19091,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -19496,7 +19414,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 30 1 *
   decorate: true
   decoration_config:
@@ -19506,9 +19424,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -19590,6 +19508,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -20006,7 +19925,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20089,7 +20008,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20161,7 +20080,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 16 * * 5
   decorate: true
   decoration_config:
@@ -20171,9 +20090,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20255,6 +20174,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -20328,7 +20248,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 26 1 *
   decorate: true
   decoration_config:
@@ -20338,9 +20258,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20495,7 +20415,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 28 1 *
   decorate: true
   decoration_config:
@@ -20505,9 +20425,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -20589,6 +20509,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.16
@@ -20745,7 +20666,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 29 1 *
   decorate: true
   decoration_config:
@@ -20755,9 +20676,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -21089,7 +21010,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -21172,7 +21093,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-nightly-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -21672,7 +21593,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-stable-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -21755,7 +21676,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.16-upgrade-from-stable-4.15
     ci.openshift.io/generator: prowgen
     job-release: "4.16"
@@ -22751,7 +22672,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -22834,7 +22755,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -22917,7 +22838,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -23155,7 +23076,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 13 2 *
   decorate: true
   decoration_config:
@@ -23165,9 +23086,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -23249,6 +23170,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -23490,7 +23412,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 5 2 *
   decorate: true
   decoration_config:
@@ -23500,9 +23422,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -23574,7 +23496,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 18 * * 5
   decorate: true
   decoration_config:
@@ -23668,6 +23590,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -23751,6 +23674,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -24073,7 +23997,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 0 8 2 *
   decorate: true
   decoration_config:
@@ -24167,6 +24091,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -24583,7 +24508,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -24666,7 +24591,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -24738,7 +24663,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 22 * * 5
   decorate: true
   decoration_config:
@@ -24832,6 +24757,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -24848,174 +24774,6 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=ocp-fips-ovn-remote-s2s-libvirt-multi-p-p
-      - --variant=nightly-4.17
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 0 4 2 *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
-    ci-operator.openshift.io/variant: nightly-4.17
-    ci.openshift.io/generator: prowgen
-    job-release: "4.17"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-multi-s390x
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-s390x
-      - --variant=nightly-4.17
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 0 5 2 *
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
-    ci-operator.openshift.io/variant: nightly-4.17
-    ci.openshift.io/generator: prowgen
-    job-release: "4.17"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-multi-z-z
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-z-z
       - --variant=nightly-4.17
       command:
       - ci-operator
@@ -25156,7 +24914,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 0 11 2 *
   decorate: true
   decoration_config:
@@ -25250,6 +25008,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17
@@ -25406,7 +25165,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 0 12 2 *
   decorate: true
   decoration_config:
@@ -25750,7 +25509,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -25833,7 +25592,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-nightly-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -25905,7 +25664,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 20 * * 5
   decorate: true
   decoration_config:
@@ -25999,6 +25758,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-nightly-4.16
@@ -26332,7 +26092,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-stable-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -26415,7 +26175,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.17-upgrade-from-stable-4.16
     ci.openshift.io/generator: prowgen
     job-release: "4.17"
@@ -27577,7 +27337,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -27660,7 +27420,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -27743,7 +27503,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -27981,7 +27741,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 20 * * 0
   decorate: true
   decoration_config:
@@ -27991,9 +27751,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -28075,6 +27835,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -28159,8 +27920,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-7
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-7
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -28316,7 +28077,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 18 * * 2,4
   decorate: true
   decoration_config:
@@ -28326,9 +28087,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -28400,7 +28161,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 18 * * 1,3
   decorate: true
   decoration_config:
@@ -28494,6 +28255,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -28577,6 +28339,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -28899,7 +28662,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 18 * * 6
   decorate: true
   decoration_config:
@@ -28993,6 +28756,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -29409,7 +29173,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -29492,7 +29256,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -29564,7 +29328,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 19 * * 6
   decorate: true
   decoration_config:
@@ -29658,6 +29422,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -29674,174 +29439,6 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=ocp-fips-ovn-remote-s2s-libvirt-multi-p-p
-      - --variant=nightly-4.18
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 19 * * 1,3
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
-    ci-operator.openshift.io/variant: nightly-4.18
-    ci.openshift.io/generator: prowgen
-    job-release: "4.18"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.18-ocp-heavy-build-ovn-remote-libvirt-multi-s390x
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-s390x
-      - --variant=nightly-4.18
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 19 * * 2,4
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
-    ci-operator.openshift.io/variant: nightly-4.18
-    ci.openshift.io/generator: prowgen
-    job-release: "4.18"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.18-ocp-heavy-build-ovn-remote-libvirt-multi-z-z
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-z-z
       - --variant=nightly-4.18
       command:
       - ci-operator
@@ -29982,7 +29579,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 18 * * 0
   decorate: true
   decoration_config:
@@ -30076,6 +29673,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18
@@ -30232,7 +29830,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 19 * * 0
   decorate: true
   decoration_config:
@@ -30576,7 +30174,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -30659,7 +30257,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-nightly-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -30731,7 +30329,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 20 * * 1-4
   decorate: true
   decoration_config:
@@ -30825,6 +30423,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-nightly-4.17
@@ -31158,7 +30757,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-stable-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -31241,7 +30840,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.18-upgrade-from-stable-4.17
     ci.openshift.io/generator: prowgen
     job-release: "4.18"
@@ -32476,7 +32075,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32484,9 +32082,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32559,7 +32158,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32567,9 +32165,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32642,7 +32241,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -32650,9 +32248,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32890,7 +32489,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 23 * * 0
   decorate: true
   decoration_config:
@@ -32900,9 +32499,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -32974,90 +32573,6 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
-  cron: 0 23 * * 0
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
-    ci-operator.openshift.io/variant: nightly-4.19
-    ci.openshift.io/generator: prowgen
-    job-release: "4.19"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.19-ocp-e2e-ovn-agent-remote-libvirt-s390x
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-e2e-ovn-agent-remote-libvirt-s390x
-      - --variant=nightly-4.19
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
   cluster: build11
   cron: 0 23 * * 0
   decorate: true
@@ -33068,6 +32583,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -33142,7 +32658,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build01
-  cron: 0 23 * * *
+  cron: 0 15 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -33152,8 +32668,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-7
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-7
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -33309,7 +32825,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 21 * * 2,4
   decorate: true
   decoration_config:
@@ -33319,9 +32835,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -33393,7 +32909,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 21 * * 1,3
   decorate: true
   decoration_config:
@@ -33487,6 +33003,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -33570,6 +33087,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -33892,7 +33410,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 21 * * 6
   decorate: true
   decoration_config:
@@ -33986,6 +33504,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -34485,7 +34004,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -34568,7 +34087,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -34640,7 +34159,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 22 * * 6
   decorate: true
   decoration_config:
@@ -34734,6 +34253,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -34750,174 +34270,6 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=ocp-fips-ovn-remote-s2s-libvirt-multi-p-p
-      - --variant=nightly-4.19
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 22 * * 1,3
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
-    ci-operator.openshift.io/variant: nightly-4.19
-    ci.openshift.io/generator: prowgen
-    job-release: "4.19"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.19-ocp-heavy-build-ovn-remote-libvirt-multi-s390x
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-s390x
-      - --variant=nightly-4.19
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 22 * * 2,4
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
-    ci-operator.openshift.io/variant: nightly-4.19
-    ci.openshift.io/generator: prowgen
-    job-release: "4.19"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.19-ocp-heavy-build-ovn-remote-libvirt-multi-z-z
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-z-z
       - --variant=nightly-4.19
       command:
       - ci-operator
@@ -35058,7 +34410,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 21 * * 0
   decorate: true
   decoration_config:
@@ -35152,6 +34504,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19
@@ -35308,7 +34661,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 22 * * 0
   decorate: true
   decoration_config:
@@ -35652,7 +35005,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -35735,7 +35088,7 @@ periodics:
     repo: multiarch
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-nightly-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -35807,7 +35160,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 23 * * 1-4
   decorate: true
   decoration_config:
@@ -35901,6 +35254,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-nightly-4.18
@@ -36234,7 +35588,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-stable-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -36317,7 +35671,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.19-upgrade-from-stable-4.18
     ci.openshift.io/generator: prowgen
     job-release: "4.19"
@@ -37721,7 +37075,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37729,9 +37082,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 186h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37814,7 +37168,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37887,7 +37241,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37895,9 +37248,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -37970,7 +37324,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -37978,9 +37331,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 192h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -38063,7 +37417,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -38301,7 +37655,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 2 * * 0
   decorate: true
   decoration_config:
@@ -38311,9 +37665,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -38395,6 +37749,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -38479,8 +37834,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -38636,7 +37991,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 * * 2,4
   decorate: true
   decoration_config:
@@ -38646,9 +38001,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-1
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-1
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -38720,7 +38075,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 0 * * 1,3
   decorate: true
   decoration_config:
@@ -38814,6 +38169,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -38897,6 +38253,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -39304,7 +38661,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 0 * * 6
   decorate: true
   decoration_config:
@@ -39398,6 +38755,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -39897,7 +39255,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -39980,7 +39338,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -40052,7 +39410,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 1 * * 6
   decorate: true
   decoration_config:
@@ -40146,6 +39504,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -40162,174 +39521,6 @@ periodics:
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/secrets/ci-pull-credentials
       - --target=ocp-fips-ovn-remote-s2s-libvirt-multi-p-p
-      - --variant=nightly-4.20
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 1 * * 1,3
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
-    ci-operator.openshift.io/variant: nightly-4.20
-    ci.openshift.io/generator: prowgen
-    job-release: "4.20"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-heavy-build-ovn-remote-libvirt-multi-s390x
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-s390x
-      - --variant=nightly-4.20
-      command:
-      - ci-operator
-      env:
-      - name: HTTP_SERVER_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
-      imagePullPolicy: Always
-      name: ""
-      ports:
-      - containerPort: 8080
-        name: http
-      resources:
-        requests:
-          cpu: 10m
-      volumeMounts:
-      - mountPath: /etc/boskos
-        name: boskos
-        readOnly: true
-      - mountPath: /secrets/ci-pull-credentials
-        name: ci-pull-credentials
-        readOnly: true
-      - mountPath: /secrets/gcs
-        name: gcs-credentials
-        readOnly: true
-      - mountPath: /secrets/manifest-tool
-        name: manifest-tool-local-pusher
-        readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
-      - mountPath: /etc/report
-        name: result-aggregator
-        readOnly: true
-    serviceAccountName: ci-operator
-    volumes:
-    - name: boskos
-      secret:
-        items:
-        - key: credentials
-          path: credentials
-        secretName: boskos-credentials
-    - name: ci-pull-credentials
-      secret:
-        secretName: ci-pull-credentials
-    - name: manifest-tool-local-pusher
-      secret:
-        secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
-    - name: result-aggregator
-      secret:
-        secretName: result-aggregator
-- agent: kubernetes
-  cluster: build09
-  cron: 0 1 * * 2,4
-  decorate: true
-  decoration_config:
-    skip_cloning: true
-  extra_refs:
-  - base_ref: main
-    org: openshift
-    repo: multiarch
-  labels:
-    capability/intranet: intranet
-    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
-    ci-operator.openshift.io/variant: nightly-4.20
-    ci.openshift.io/generator: prowgen
-    job-release: "4.20"
-    pj-rehearse.openshift.io/can-be-rehearsed: "true"
-  name: periodic-ci-openshift-multiarch-main-nightly-4.20-ocp-heavy-build-ovn-remote-libvirt-multi-z-z
-  spec:
-    containers:
-    - args:
-      - --gcs-upload-secret=/secrets/gcs/service-account.json
-      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --lease-server-credentials-file=/etc/boskos/credentials
-      - --report-credentials-file=/etc/report/credentials
-      - --secret-dir=/secrets/ci-pull-credentials
-      - --target=ocp-heavy-build-ovn-remote-libvirt-multi-z-z
       - --variant=nightly-4.20
       command:
       - ci-operator
@@ -40470,7 +39661,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 0 * * 0
   decorate: true
   decoration_config:
@@ -40564,6 +39755,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20
@@ -40720,7 +39912,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 1 * * 0
   decorate: true
   decoration_config:
@@ -41064,7 +40256,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -41147,7 +40339,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-nightly-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -41219,7 +40411,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 2 * * 1-4
   decorate: true
   decoration_config:
@@ -41313,6 +40505,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-nightly-4.19
@@ -41729,7 +40922,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-stable-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -41812,7 +41005,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.20-upgrade-from-stable-4.19
     ci.openshift.io/generator: prowgen
     job-release: "4.20"
@@ -43216,7 +42409,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -43224,9 +42416,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 204h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43309,7 +42502,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43382,7 +42575,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -43390,9 +42582,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 216h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43465,7 +42658,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -43473,9 +42665,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 210h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43558,7 +42751,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43796,7 +42989,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 5 * * 0
   decorate: true
   decoration_config:
@@ -43806,9 +42999,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -43890,6 +43083,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -43964,7 +43158,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 1 * * *
+  cron: 0 0 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -44059,8 +43253,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -44216,7 +43410,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 3 * * 6
   decorate: true
   decoration_config:
@@ -44226,9 +43420,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -44300,7 +43494,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 4 * * 6
   decorate: true
   decoration_config:
@@ -44394,6 +43588,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -44477,6 +43672,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -44884,7 +44080,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 4 * * 1-4
   decorate: true
   decoration_config:
@@ -44978,6 +44174,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -45477,7 +44674,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -45560,7 +44757,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -45632,7 +44829,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 3 * * 1-4
   decorate: true
   decoration_config:
@@ -45726,6 +44923,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -45882,7 +45080,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 3 * * 0
   decorate: true
   decoration_config:
@@ -45976,6 +45174,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21
@@ -46132,7 +45331,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 4 * * 0
   decorate: true
   decoration_config:
@@ -46476,7 +45675,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -46559,7 +45758,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-nightly-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -46631,7 +45830,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 5 * * 1-4
   decorate: true
   decoration_config:
@@ -46725,6 +45924,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-nightly-4.20
@@ -47141,7 +46341,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-stable-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -47224,7 +46424,7 @@ periodics:
   interval: 72h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.21-upgrade-from-stable-4.20
     ci.openshift.io/generator: prowgen
     job-release: "4.21"
@@ -48628,7 +47828,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -48636,9 +47835,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48718,10 +47918,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48794,7 +47994,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -48802,9 +48001,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48877,7 +48077,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -48885,9 +48084,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 192h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -48967,10 +48167,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -49208,7 +48408,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 8 * * 0
   decorate: true
   decoration_config:
@@ -49218,9 +48418,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -49302,6 +48502,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -49471,8 +48672,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -49628,7 +48829,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 6 * * 6
   decorate: true
   decoration_config:
@@ -49638,9 +48839,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -49712,7 +48913,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 7 * * 6
   decorate: true
   decoration_config:
@@ -49806,6 +49007,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -49889,6 +49091,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -49962,7 +49165,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 10 * * 1-4
   decorate: true
   decoration_config:
@@ -50056,6 +49259,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -50297,7 +49501,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 9 * * 1-4
   decorate: true
   decoration_config:
@@ -50391,6 +49595,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -50630,7 +49835,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 7 * * 1-4
   decorate: true
   decoration_config:
@@ -50724,6 +49929,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -50807,6 +50013,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -51303,10 +50510,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 186h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -51386,10 +50593,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 204h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -51461,7 +50668,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 6 * * 1-4
   decorate: true
   decoration_config:
@@ -51555,6 +50762,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -51711,7 +50919,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 6 * * 0
   decorate: true
   decoration_config:
@@ -51805,6 +51013,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.22
@@ -51961,7 +51170,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 7 * * 0
   decorate: true
   decoration_config:
@@ -52305,7 +51514,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22-upgrade-from-nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -52388,7 +51597,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22-upgrade-from-nightly-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -52460,7 +51669,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 8 * * 1-4
   decorate: true
   decoration_config:
@@ -52971,7 +52180,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22-upgrade-from-stable-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -53054,7 +52263,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.22-upgrade-from-stable-4.21
     ci.openshift.io/generator: prowgen
     job-release: "4.22"
@@ -54458,7 +53667,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -54466,9 +53674,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 210h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54551,7 +53760,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54624,7 +53833,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -54632,9 +53840,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 186h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54707,7 +53916,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -54715,9 +53923,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -54797,10 +54006,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 216h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -55038,7 +54247,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 7 4 *
   decorate: true
   decoration_config:
@@ -55048,9 +54257,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -55132,6 +54341,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -55206,7 +54416,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 4 * * *
+  cron: 0 8 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -55301,8 +54511,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-3
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-3
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -55458,7 +54668,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 9 4 *
   decorate: true
   decoration_config:
@@ -55468,9 +54678,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -55542,7 +54752,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 31 3 *
   decorate: true
   decoration_config:
@@ -55552,9 +54762,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -55636,6 +54846,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -55719,6 +54930,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -55960,7 +55172,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build09
+  cluster: build12
   cron: 0 0 8 4 *
   decorate: true
   decoration_config:
@@ -56054,6 +55266,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -56293,7 +55506,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 4 4 *
   decorate: true
   decoration_config:
@@ -56303,9 +55516,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -56387,6 +55600,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -56470,6 +55684,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -56966,10 +56181,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57049,10 +56264,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 192h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57124,7 +56339,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 5 4 *
   decorate: true
   decoration_config:
@@ -57134,9 +56349,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57218,6 +56433,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -57374,7 +56590,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 2 4 *
   decorate: true
   decoration_config:
@@ -57384,9 +56600,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57468,6 +56684,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-4.23
@@ -57624,7 +56841,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 0 3 4 *
   decorate: true
   decoration_config:
@@ -57634,9 +56851,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-4.23
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -57968,7 +57185,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -58051,7 +57268,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -58634,7 +57851,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -58717,7 +57934,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-4.23-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     job-release: "4.23"
@@ -61631,7 +60848,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61639,9 +60855,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 198h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61721,10 +60938,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 210h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61797,7 +61014,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61805,9 +61021,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 174h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61880,7 +61097,6 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build08
-  cron: 0 11 * * 0
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -61888,9 +61104,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
+  interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -61970,10 +61187,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 204h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62211,7 +61428,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 8 * * 0
   decorate: true
   decoration_config:
@@ -62221,9 +61438,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62305,6 +61522,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -62379,7 +61597,7 @@ periodics:
         secretName: result-aggregator
 - agent: kubernetes
   cluster: build11
-  cron: 0 4 * * *
+  cron: 0 12 * * *
   decorate: true
   decoration_config:
     skip_cloning: true
@@ -62474,8 +61692,8 @@ periodics:
     repo: multiarch
   labels:
     capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: powervs-8
-    ci-operator.openshift.io/cloud-cluster-profile: powervs-8
+    ci-operator.openshift.io/cloud: powervs-6
+    ci-operator.openshift.io/cloud-cluster-profile: powervs-6
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62631,7 +61849,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 6 * * 6
   decorate: true
   decoration_config:
@@ -62641,9 +61859,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62715,7 +61933,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 7 * * 6
   decorate: true
   decoration_config:
@@ -62725,9 +61943,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -62809,6 +62027,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -62892,6 +62111,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -63299,7 +62519,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 7 * * 1-4
   decorate: true
   decoration_config:
@@ -63309,9 +62529,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -63393,6 +62613,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -63476,6 +62697,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -63972,10 +63194,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 216h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64055,10 +63277,10 @@ periodics:
   - base_ref: main
     org: openshift
     repo: multiarch
-  interval: 168h
+  interval: 180h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64130,7 +63352,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 6 * * 1-4
   decorate: true
   decoration_config:
@@ -64140,9 +63362,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64224,6 +63446,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -64380,7 +63603,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 6 * * 0
   decorate: true
   decoration_config:
@@ -64390,9 +63613,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64474,6 +63697,7 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
+    capability/power-s2s-dns: power-s2s-dns
     ci-operator.openshift.io/cloud: libvirt-ppc64le-s2s
     ci-operator.openshift.io/cloud-cluster-profile: libvirt-ppc64le-s2s
     ci-operator.openshift.io/variant: nightly-5.0
@@ -64630,7 +63854,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 7 * * 0
   decorate: true
   decoration_config:
@@ -64640,9 +63864,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -64974,7 +64198,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -65057,7 +64281,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -65129,7 +64353,7 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
-  cluster: build01
+  cluster: build12
   cron: 0 8 * * 1-4
   decorate: true
   decoration_config:
@@ -65139,9 +64363,9 @@ periodics:
     org: openshift
     repo: multiarch
   labels:
-    capability/sshd-bastion: sshd-bastion
-    ci-operator.openshift.io/cloud: libvirt-s390x-2
-    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-2
+    capability/intranet: intranet
+    ci-operator.openshift.io/cloud: libvirt-s390x-vpn
+    ci-operator.openshift.io/cloud-cluster-profile: libvirt-s390x-vpn
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-nightly-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -65640,7 +64864,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"
@@ -65723,7 +64947,7 @@ periodics:
   interval: 168h
   labels:
     ci-operator.openshift.io/cloud: gcp
-    ci-operator.openshift.io/cloud-cluster-profile: gcp-arm64
+    ci-operator.openshift.io/cloud-cluster-profile: openshift-org-gcp
     ci-operator.openshift.io/variant: nightly-5.0-upgrade-from-stable-4.22
     ci.openshift.io/generator: prowgen
     job-release: "5.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What this PR changes (practical impact)

This PR updates the OpenShift CI configuration for the multiarch repository's nightly upgrade job matrix that validates upgrades from nightly 4.20 → nightly 4.21. It adjusts test environment resource sizing and DNS/workflow settings for heterogeneous and libvirt-based upgrade jobs used by CI.

- Affected repo: openshift/multiarch (ci-operator job configuration)
- Affected CI area: nightly multi-architecture upgrade tests (ci-operator config for upgrade validation)

## Key changes

- GCP heterogeneous upgrade (ocp-e2e-upgrade-gcp-ovn-multi-x-ax)
  - Increased ADDITIONAL_WORKER_VM_TYPE from t2a-standard-2 → t2a-standard-4 (more ARM worker resources for mixed-arch upgrade testing).
  - OCP_ARCH remains amd64 and the job continues to use the openshift-org-gcp cluster_profile.

- GCP single-arch ARM upgrade (ocp-e2e-upgrade-gcp-ovn-multi-a-a)
  - COMPUTE_NODE_TYPE is set to t2a-standard-4 for arm64 compute nodes.

- libvirt/remote upgrade jobs
  - The libvirt s2s UPI upgrade job (ocp-ovn-remote-s2s-libvirt-multi-p-p) now sets USE_EXTERNAL_DNS: "true" and uses the openshift-e2e-libvirt-upi workflow.
  - The separate libvirt VPN test (ocp-ovn-remote-libvirt-multi-z-z) also sets USE_EXTERNAL_DNS: "true".
  - A previously-present capability entry (power-s2s-dns) was removed from the s2s/libvirt entries.

- Metadata
  - zz_generated_metadata.variant set to nightly-4.21-upgrade-from-nightly-4.20 to identify this upgrade scenario.

## Other notes
- Changes are limited to CI job YAML (no code/public API changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->