### PR TITLE
Fix ROSA account-roles-create overriding specific patch versions

### DIFF
--- a/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
+++ b/ci-operator/step-registry/rosa/sts/account-roles/create/rosa-sts-account-roles-create-commands.sh
@@ -12,6 +12,7 @@ OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-}
 CHANNEL_GROUP=${CHANNEL_GROUP}
 PERMISSIONS_BOUNDARY=${PERMISSIONS_BOUNDARY:-}
 ACCOUNT_ROLES_PREFIX=$(head -n 1 "${SHARED_DIR}/cluster-prefix")
+FALLBACK_OCCURRED=false
 
 # Configure aws
 AWSCRED="${CLUSTER_PROFILE_DIR}/.awscred"
@@ -121,6 +122,7 @@ elif [[ "${create_ret}" -ne 0 ]]; then
     echo "Retrying with version ${fallback_version} (was ${OPENSHIFT_VERSION})"
     OPENSHIFT_VERSION="${fallback_version}"
     VERSION_SWITCH="--version ${OPENSHIFT_VERSION} --channel-group ${CHANNEL_GROUP}"
+    FALLBACK_OCCURRED=true
     rosa create account-roles -y --mode auto \
                               --prefix ${ACCOUNT_ROLES_PREFIX} \
                               ${CLUSTER_SWITCH} \
@@ -134,10 +136,10 @@ elif [[ "${create_ret}" -ne 0 ]]; then
   fi
 fi
 
-# Share the resolved version (includes fallback if one was used)
-if [[ "${CHANNEL_GROUP}" != "stable" && -n "${OPENSHIFT_VERSION:-}" ]]; then
+# Share the resolved version only if a fallback occurred
+if [[ "${FALLBACK_OCCURRED}" == "true" && "${CHANNEL_GROUP}" != "stable" && -n "${OPENSHIFT_VERSION:-}" ]]; then
   echo -n "${OPENSHIFT_VERSION}" > "${SHARED_DIR}/openshift_version"
-  echo "Stored resolved version ${OPENSHIFT_VERSION} to SHARED_DIR"
+  echo "Stored fallback version ${OPENSHIFT_VERSION} to SHARED_DIR"
 fi
 
 # Store the account-role-prefix for the next pre steps and the account roles deletion


### PR DESCRIPTION
The account-roles-create step was unconditionally writing the truncated version (e.g., "4.21") to ${SHARED_DIR}/openshift_version, even when no fallback occurred. This caused the provision step to override specific patch version requests (e.g., OPENSHIFT_VERSION: 4.21.13) with the latest available version in that minor release (e.g., 4.21.15).

The openshift_version file is intended to communicate fallback versions when account role creation fails with the requested version and must retry with a newer one. It should not be written during normal operations where the user's requested version succeeds.

Changes:
- Add FALLBACK_OCCURRED flag to track actual fallback events
- Only write openshift_version file when fallback actually occurs
- Update log message to clarify it's storing a fallback version

This ensures that when users specify exact versions like "4.21.13" in their job configs, the cluster is provisioned with that exact version rather than being upgraded to the latest available patch release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix ROSA account-roles-create overriding specific patch versions

This PR fixes an issue in the ROSA (Red Hat OpenShift Service on AWS) CI infrastructure where the `account-roles-create` step was unintentionally overriding user-specified OpenShift patch versions.

### Problem
The `account-roles-create` step was unconditionally writing a truncated minor version (e.g., "4.21") to `${SHARED_DIR}/openshift_version` even when no fallback was necessary. This caused the downstream provision step to replace user-requested specific patch versions (e.g., `OPENSHIFT_VERSION: 4.21.13`) with the latest patch available in that minor release (e.g., 4.21.15), breaking reproducible cluster provisioning.

### Solution
Modified the `rosa-sts-account-roles-create-commands.sh` step to:
- Introduce a `FALLBACK_OCCURRED` flag initialized to `false` that tracks whether account role creation actually required falling back to a different OpenShift version
- Set `FALLBACK_OCCURRED=true` only when the fallback retry path is executed with a different version
- Conditionally write `openshift_version` to the shared directory only when a fallback has genuinely occurred (checking both the flag and that `OPENSHIFT_VERSION` is set)
- Update the log message from generic version storage to clarify "Stored fallback version"

### Impact
The fix ensures that exact user-specified OpenShift patch versions are preserved during normal CI operations. The `openshift_version` file is now correctly used only as a fallback communication mechanism when account role creation fails with the requested version and must retry with an alternative version, preventing unintended version overrides in downstream provisioning steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->