### PR TITLE
SPLAT-2592: Removed logic that adds the platform-type labels to nodes for hybrid-env

### DIFF
--- a/ci-operator/step-registry/ipi/install/vsphere/virt/ipi-install-vsphere-virt-commands.sh
+++ b/ci-operator/step-registry/ipi/install/vsphere/virt/ipi-install-vsphere-virt-commands.sh
@@ -37,20 +37,6 @@ function approve_csrs() {
   done
 }
 
-# Add 'node.openshift.io/platform-type=vsphere' label to any node that is missing it.
-function label_vsphere_nodes() {
-  echo "$(date -u --rfc-3339=seconds) - Adding labels to vsphere nodes for builds that do not have upstream ccm changes..."
-  NODES=$(oc get nodes -o name --kubeconfig="${CLUSTER_KUBECONFIG}")
-  for node in ${NODES}; do
-    echo "$(date -u --rfc-3339=seconds) - Checking ${node}"
-    LABEL_FOUND=$(oc get ${node} -o json | jq -r '.metadata.labels | has("node.openshift.io/platform-type")')
-    if [ "${LABEL_FOUND}" == "false" ]; then
-      echo "$(date -u --rfc-3339=seconds) - Adding 'node.openshift.io/platform-type=vsphere' label"
-      oc label "${node}" "node.openshift.io/platform-type"=vsphere --kubeconfig="${CLUSTER_KUBECONFIG}"
-    fi
-  done
-}
-
 # Enable storage operator / capability.  If operator is already enabled, this function will log no changes made and operator is ready.
 function enable_storage_operator() {
   echo "$(date -u --rfc-3339=seconds) - Enabling storage capability (operator)..."
@@ -110,10 +96,6 @@ function patch_csi_driver_removed() {
   echo "$(date -u --rfc-3339=seconds) - Patching clustercsidriver managementState to be Removed"
   oc patch clustercsidriver csi.vsphere.vmware.com --type=merge --patch 'spec: {managementState: "Removed"}'
 }
-
-# We are going to apply the 'node.openshift.io/platform-type=vsphere' label to all existing nodes as a workaround while waiting for upstream CCM changes
-# When upstream changes are merged downstream, the function will output that no nodes were updated.
-label_vsphere_nodes
 
 # Enable storage operator now that the labels are in place
 if [ "${ENABLE_HYBRID_STORAGE}" == "true" ]; then


### PR DESCRIPTION
[SPLAT-2592](https://redhat.atlassian.net/browse/SPLAT-2592)

### Changes
- Removed logic that adds the platform-type labels to nodes for hybrid-env

[SPLAT-2592]: https://redhat.atlassian.net/browse/SPLAT-2592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Removed platform-type labeling workaround for vSphere hybrid environments

This PR removes a downstream workaround from the vSphere IPI installer step that was adding `node.openshift.io/platform-type=vsphere` labels to nodes in hybrid-environment clusters.

**What changed:**
The `label_vsphere_nodes()` helper function and its invocation (18 lines) have been removed from the vSphere virtualization installation script (`ci-operator/step-registry/ipi/install/vsphere/virt/ipi-install-vsphere-virt-commands.sh`). This script is used during CI testing to set up hybrid clusters with vSphere virtual machine nodes.

**Practical impact:**
The vSphere hybrid environment CI tests no longer perform manual node labeling after CSR approval. The script now proceeds directly from node approval to storage and cluster operator configuration. This change suggests that upstream Cloud Controller Manager (CCM) changes have been deployed, making the temporary downstream labeling workaround unnecessary.

**Affected infrastructure:**
CI configuration for OpenShift clusters using vSphere virtualization with hybrid node types in integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->