### PR TITLE
Correcting vertex credentials

### DIFF
--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
@@ -91,6 +91,8 @@ tests:
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
         export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        sleep 100000 &
+        wait
         ls /var/run/vertex
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
@@ -91,7 +91,7 @@ tests:
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
         export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
         export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
-
+        ls /var/run/vertex
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
         export MODEL=gpt-4o-mini

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml
@@ -89,11 +89,9 @@ tests:
         export AZUREOPENAI_ENTRA_ID_CLIENT_SECRET=$(cat /var/run/azureopenai-entra-id/client_secret)
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
-        sleep 100000 &
-        wait
-        ls /var/run/vertex
+        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
+
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
         export MODEL=gpt-4o-mini
@@ -157,7 +155,7 @@ tests:
         export AZUREOPENAI_PROVIDER_KEY_PATH=/var/run/azure_openai/token
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         tests/scripts/test-evaluation.sh
       credentials:

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.16.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.16.yaml
@@ -50,8 +50,8 @@ tests:
         export AZUREOPENAI_ENTRA_ID_CLIENT_SECRET=$(cat /var/run/azureopenai-entra-id/client_secret)
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.17.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.17.yaml
@@ -58,8 +58,8 @@ tests:
         export AZUREOPENAI_ENTRA_ID_CLIENT_SECRET=$(cat /var/run/azureopenai-entra-id/client_secret)
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.18.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.18.yaml
@@ -54,8 +54,8 @@ tests:
         export AZUREOPENAI_ENTRA_ID_CLIENT_SECRET=$(cat /var/run/azureopenai-entra-id/client_secret)
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.19.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.19.yaml
@@ -50,8 +50,8 @@ tests:
         export AZUREOPENAI_ENTRA_ID_CLIENT_SECRET=$(cat /var/run/azureopenai-entra-id/client_secret)
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -116,7 +116,7 @@ tests:
         export AZUREOPENAI_PROVIDER_KEY_PATH=/var/run/azure_openai/token
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         tests/scripts/test-evaluation.sh
       credentials:

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.20.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.20.yaml
@@ -50,8 +50,8 @@ tests:
         export AZUREOPENAI_ENTRA_ID_CLIENT_SECRET=$(cat /var/run/azureopenai-entra-id/client_secret)
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -116,7 +116,7 @@ tests:
         export AZUREOPENAI_PROVIDER_KEY_PATH=/var/run/azure_openai/token
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         tests/scripts/test-evaluation.sh
       credentials:

--- a/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.21.yaml
+++ b/ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main__4.21.yaml
@@ -50,8 +50,8 @@ tests:
         export AZUREOPENAI_ENTRA_ID_CLIENT_SECRET=$(cat /var/run/azureopenai-entra-id/client_secret)
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export RHAIIS_PROVIDER_KEY_PATH=/var/run/rhaiis/token
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         export PROVIDER_KEY_PATH=/var/run/openai/token
         export PROVIDER=openai
@@ -116,7 +116,7 @@ tests:
         export AZUREOPENAI_PROVIDER_KEY_PATH=/var/run/azure_openai/token
         export OPENAI_PROVIDER_KEY_PATH=/var/run/openai/token
         export WATSONX_PROVIDER_KEY_PATH=/var/run/watsonx/token
-        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex
+        export VERTEX_PROVIDER_KEY_PATH=/var/run/vertex/token
 
         tests/scripts/test-evaluation.sh
       credentials:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the OpenShift CI configuration for the openshift/lightspeed-service repository to consistently read provider credentials from mounted token files and adds a small debugging step to the main e2e job to help diagnose credential mounting.

Concretely:
- Affected CI configs: ci-operator/config/openshift/lightspeed-service/* (main and per-OCP-version variants).
- What changed:
  - The various e2e and periodic job command blocks were changed to set provider key environment variables to token-file paths (e.g., VERTEX_PROVIDER_KEY_PATH, RHAIIS_PROVIDER_KEY_PATH, AZUREOPENAI_PROVIDER_KEY_PATH, etc.) under /var/run/<provider>/token instead of the previous directory paths.
  - A debugging line, ls /var/run/vertex, was added to the e2e-ols-cluster test commands in ci-operator/config/openshift/lightspeed-service/openshift-lightspeed-service-main.yaml (placed immediately after exporting VERTEX_PROVIDER_KEY_PATH) to verify the Vertex credential mount.
- Scope and intent: These are CI/operator YAML changes only (no code or public API changes). The change is marked WIP and was intended to trigger a rehearsal run to validate credential mounting and token path usage across e2e and periodic jobs for multiple OCP variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->