### PR TITLE
fix: update multicluster-global-hub Prow builder to go1.25-linux for release-2.12 to release-2.17

### DIFF
--- a/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.12.yaml
+++ b/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.12.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: operator/Dockerfile

--- a/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.13.yaml
+++ b/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.13.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.23-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: operator/Dockerfile

--- a/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.14.yaml
+++ b/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.14.yaml
@@ -7,7 +7,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.22-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: operator/Dockerfile

--- a/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.15.yaml
+++ b/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.15.yaml
@@ -3,15 +3,15 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.22-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: operator/Dockerfile

--- a/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.16.yaml
+++ b/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.16.yaml
@@ -3,15 +3,15 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.22-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: operator/Dockerfile

--- a/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.17.yaml
+++ b/ci-operator/config/stolostron/multicluster-global-hub/stolostron-multicluster-global-hub-release-2.17.yaml
@@ -3,15 +3,15 @@ base_images:
     name: ubi-minimal
     namespace: ocp
     tag: "9"
-  stolostron_builder_go1.24-linux:
+  stolostron_builder_go1.25-linux:
     name: builder
     namespace: stolostron
-    tag: go1.24-linux
+    tag: go1.25-linux
 build_root:
   image_stream_tag:
     name: builder
     namespace: stolostron
-    tag: go1.22-linux
+    tag: go1.25-linux
 images:
   items:
   - dockerfile_path: operator/Dockerfile


### PR DESCRIPTION
## Summary

All `multicluster-global-hub` release branches (2.12–2.17) already use Go 1.25.x in `go.mod`, but the Prow CI configs still reference older builders (`go1.22-linux`, `go1.23-linux`, `go1.24-linux`).

This PR updates all six release branch configs to use `go1.25-linux`, consistent with other stolostron projects on the same branches (e.g. `multiclusterhub-operator`, `governance-policy-addon-controller`).

## Changes

| Branch | Before | After |
|--------|--------|-------|
| release-2.12 | `go1.23-linux` | `go1.25-linux` |
| release-2.13 | `go1.23-linux` | `go1.25-linux` |
| release-2.14 | `go1.22-linux` | `go1.25-linux` |
| release-2.15 | `go1.24-linux` / `go1.22-linux` | `go1.25-linux` |
| release-2.16 | `go1.24-linux` / `go1.22-linux` | `go1.25-linux` |
| release-2.17 | `go1.24-linux` / `go1.22-linux` | `go1.25-linux` |

## Verification

- `go1.25-linux` is already used by other stolostron projects on `release-2.12` (e.g. `multiclusterhub-operator`) and on older backplane branches
- All affected branches have `go 1.25.x` in their `go.mod`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the CI/Prow builder configuration for the stolostron multicluster-global-hub repository across release branches 2.12 through 2.17 to use the `go1.25-linux` builder image.

## What's changing

This PR synchronizes the Go toolchain version used by Prow CI with the actual Go version requirements declared in the project. All six affected release branches (2.12, 2.13, 2.14, 2.15, 2.16, 2.17) have Go 1.25.x specified in their `go.mod` files, but their CI configurations were still referencing older builder images:
- Releases 2.12 and 2.13: Updates from `go1.23-linux` to `go1.25-linux`
- Releases 2.14, 2.15, 2.16, and 2.17: Updates from `go1.22-linux` or `go1.24-linux` to `go1.25-linux`

## Why this matters

The mismatch between the declared Go version and the CI builder image was causing build and test failures. By updating the Prow builder configuration to match the actual Go 1.25.x requirements, builds will now use the correct Go compiler version, resolving these failures.

## Implementation details

Six CI configuration files in `ci-operator/config/stolostron/multicluster-global-hub/` are modified to set `build_root.image_stream_tag.tag` to `go1.25-linux`. The `go1.25-linux` builder is already in use by other stolostron projects on the same release branches, establishing this as the standard build environment for the group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->