### PR TITLE
OSAC: use pruned vmaas snapshot to fix e2e disk pressure

### DIFF
--- a/ci-operator/step-registry/osac-project/cluster-tool/boot/osac-project-cluster-tool-boot-commands.sh
+++ b/ci-operator/step-registry/osac-project/cluster-tool/boot/osac-project-cluster-tool-boot-commands.sh
@@ -272,7 +272,7 @@ echo "=== Pulling OSAC vmaas flavor ==="
 python3 /usr/local/bin/cluster-tool pull "${FLAVOR_IMAGE}"
 
 echo "=== Booting cluster ==="
-python3 /usr/local/bin/cluster-tool boot --flavor osac-vmaas --name "${CLONE}"
+python3 /usr/local/bin/cluster-tool boot --flavor osac-vmaas-pruned --name "${CLONE}"
 
 systemctl restart dnsmasq
 

--- a/ci-operator/step-registry/osac-project/cluster-tool/boot/osac-project-cluster-tool-boot-ref.yaml
+++ b/ci-operator/step-registry/osac-project/cluster-tool/boot/osac-project-cluster-tool-boot-ref.yaml
@@ -34,7 +34,7 @@ ref:
     default: "main"
     documentation: cluster-tool git ref to download (branch, tag, or commit)
   - name: CLUSTER_TOOL_FLAVOR_IMAGE
-    default: "quay.io/rh-ee-ovishlit/cluster-flavors:osac-vmaas"
+    default: "quay.io/rh-ee-ovishlit/cluster-flavors:osac-vmaas-pruned"
     documentation: OCI image containing the OSAC snapshot flavor
   documentation: |-
     Boots an OSAC cluster from a pre-built snapshot using cluster-tool,


### PR DESCRIPTION
## Summary

- Switch e2e-vmaas CI jobs to use a pruned snapshot image that boots at 54% disk usage instead of 85-86%
- The old snapshot accumulated ~30 stale OLM catalog index images (~42GB) that pushed the node above kubelet's disk pressure eviction threshold on boot
- This caused ~60% of e2e-vmaas runs across all OSAC repos to fail with rollout timeouts in the refresh script's step [7/8] ("1 old replicas are pending termination")

## Root Cause

The `osac-vmaas` snapshot boots at 85-86% disk usage (79G/93G). Kubelet's image GC threshold is 85%. When the node exceeds this, kubelet sets `DiskPressure=True` taint, preventing new pods from being scheduled. The refresh script's `oc rollout restart` creates new pods that can't schedule, and `oc rollout status --timeout=120s` times out.

Exhaustive analysis of all 51 recent e2e-vmaas runs confirmed: every rollout-timeout failure (25/25) had DiskPressure=True, every success (19/19) had DiskPressure=False.

## Fix

Pruned stale OLM catalog index images from the snapshot and re-snapshotted:
- `certified-operator-index`: 9 stale versions × 1.25GB
- `community-operator-index`: 12 stale versions × 1.25GB  
- `redhat-operator-index`: 9 stale versions × 1.79GB

Also ran `refresh-after-snapshot.sh` to update OSAC component images to latest.

## Verification

- Booted from pruned snapshot: DiskPressure=False immediately, 54% disk usage (44G free)
- Original snapshot: DiskPressure=True on boot, 85% disk usage (14G free)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes recurring DiskPressure failures in the OSAC e2e-vmaas CI jobs in this repository's OpenShift CI configuration by switching cluster boot to a pruned OSAC snapshot that greatly reduces disk usage at node boot.

## Problem

e2e-vmaas CI clusters were booting from a snapshot that contained ~30 stale OLM catalog index images (~42 GB), causing nodes to start at ~85–86% disk usage (≈14 GB free). Kubelet's 85% image-garbage-collection threshold immediately set the DiskPressure=True taint on boot, blocking pod scheduling during the refresh/rollout step and causing ~60% of e2e-vmaas runs to fail.

## Solution

The snapshot used for provisioning was pruned to remove stale OLM catalog index images, re-snapshotted, and OSAC component images were refreshed. Boot now uses the pruned flavor so nodes start with ~54% disk usage (≈44 GB free) and DiskPressure=False, preventing the rollout timeouts.

## Changes (practical impact)

- Affects OpenShift CI step definitions for the OSAC project (e2e-vmaas jobs) in this repo: the cluster boot step now points at the pruned snapshot image.
- Updated ci-operator step default and boot script to use the pruned flavor image tag:
  - ci-operator/step-registry/osac-project/cluster-tool/boot/osac-project-cluster-tool-boot-ref.yaml — CLUSTER_TOOL_FLAVOR_IMAGE default changed to quay.io/rh-ee-ovishlit/cluster-flavors:osac-vmaas-pruned
  - ci-operator/step-registry/osac-project/cluster-tool/boot/osac-project-cluster-tool-boot-commands.sh — cluster-tool boot command uses the osac-vmaas-pruned flavor
- Ran refresh-after-snapshot.sh to update OSAC component images against the pruned snapshot.
- Verification: boot from pruned snapshot yields DiskPressure=False and ~54% disk usage; original snapshot reproduces DiskPressure=True and ~85% usage.

## Notes

- The author posted pj-rehearse commands to rehearse affected e2e-vmaas jobs across OSAC projects and then targeted a narrower rehearse for the installer job.
- One commit updates the boot command to match the new pruned flavor name registered by cluster-tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->