### PR TITLE
AGENT-1517:  run IRI deletion tests

### DIFF
--- a/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml
+++ b/ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml
@@ -106,7 +106,11 @@ tests:
     - ref: agent-e2e-compact-ipv4-iso-no-registry-validation
     - as: iri-e2e-step
       cli: latest
-      commands: make test-e2e-iri
+      commands: |
+        #!/usr/bin/env bash
+        set -xeuo pipefail
+        make test-e2e-iri
+        TAGS=iri_delete make test-e2e-iri
       from: src
       resources:
         requests:


### PR DESCRIPTION
This patch adds the IRI deletion e2e tests to the iso-no-registry job.

Requires https://github.com/openshift/machine-config-operator/pull/6041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## IRI Deletion E2E Tests for Machine Config Operator CI

This PR updates the OpenShift CI configuration for the machine-config-operator repository to add IRI (Isolated Red Image) deletion validation to the iso-no-registry end-to-end job.

Practically, the change modifies the e2e-compact-ipv4-iso-no-registry step in ci-operator/config/openshift/machine-config-operator/openshift-machine-config-operator-main.yaml so the iri-e2e-step runs two commands: the existing standard IRI e2e tests (make test-e2e-iri) and then the deletion-specific IRI tests (TAGS=iri_delete make test-e2e-iri) under set -xeuo pipefail. This ensures both regular IRI behavior and IRI deletion are exercised in the machine-config-operator CI job that runs without a registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->