### PR TITLE
USHIFT-6935: MicroShift CI Doctor: enable auto-bug creation and add report refresh command

### DIFF
--- a/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
+++ b/ci-operator/step-registry/openshift/edge-tooling/microshift-ci/doctor/openshift-edge-tooling-microshift-ci-doctor-commands.sh
@@ -11,6 +11,7 @@ mkdir -p "${CLAUDE_HOME}"
 
 CLAUDE_ANALYSIS_LOG="${WORKDIR}/claude-analysis.log"
 CLAUDE_BUG_CREATION_LOG="${WORKDIR}/claude-bug-creation.log"
+CLAUDE_REPORT_REFRESH_LOG="${WORKDIR}/claude-report-refresh.log"
 JIRA_MCP_LOG="${WORKDIR}/jira-mcp.log"
 
 # The procedure to copy reports and session logs to artifacts, executed at exit
@@ -42,7 +43,7 @@ atexit_handler() {
     fi
 
     # Check if the Claude sessions were completed successfully
-    for log_file in "${CLAUDE_ANALYSIS_LOG}" "${CLAUDE_BUG_CREATION_LOG}"; do
+    for log_file in "${CLAUDE_ANALYSIS_LOG}" "${CLAUDE_BUG_CREATION_LOG}" "${CLAUDE_REPORT_REFRESH_LOG}"; do
         # If a session was terminated due to a timeout, report lack of
         # subsequent session log files as a warning and continue not
         # to mask the actual error
@@ -232,10 +233,9 @@ cd "${SRC_DIR}"
 # Configure the GitHub token for MicroShift repo operations
 { set +x; export GITHUB_TOKEN="${GITHUB_TOKEN_USHIFT}"; set -x; }
 
-# Run analysis on all releases and open rebase PRs.
-# Time-box analysis and limit turns to avoid uncontrolled billable minutes.
+# Run analysis on all releases and open rebase PRs (45m and 100 turns).
 echo "Running Claude to analyze MicroShift CI jobs and pull requests..."
-timeout 3000 claude \
+timeout 2700 claude \
     --model "${CLAUDE_MODEL}" \
     --max-turns 100 \
     --output-format stream-json \
@@ -244,17 +244,27 @@ timeout 3000 claude \
     --verbose 2>&1 | tee "${CLAUDE_ANALYSIS_LOG}"
 echo "Analysis for MicroShift CI jobs and pull requests completed"
 
-# Run bug creation for failed jobs (dry-run mode).
-# Time-box bug creation and limit turns to avoid uncontrolled billable minutes.
+# Run bug creation for failed jobs (10m and 50 turns).
 echo "Running Claude to create bugs for failed jobs..."
 timeout 600 claude \
     --model "${CLAUDE_MODEL}" \
     --max-turns 50 \
     --output-format stream-json \
     --plugin-dir "${PLUGIN_DIR}" \
-    -p "/microshift-ci:create-bugs ${RELEASE_VERSIONS}" \
+    -p "/microshift-ci:create-bugs ${RELEASE_VERSIONS} --create --auto" \
     --verbose 2>&1 | tee "${CLAUDE_BUG_CREATION_LOG}"
 echo "Bug creation for failed jobs completed"
+
+# Run HTML report refresh to include the new bugs (5m and 30 turns).
+echo "Running Claude to refresh the HTML report..."
+timeout 300 claude \
+    --model "${CLAUDE_MODEL}" \
+    --max-turns 30 \
+    --output-format stream-json \
+    --plugin-dir "${PLUGIN_DIR}" \
+    -p "/microshift-ci:doctor-refresh ${RELEASE_VERSIONS}" \
+    --verbose 2>&1 | tee "${CLAUDE_REPORT_REFRESH_LOG}"
+echo "HTML report refresh completed"
 
 # Close duplicate rebase PRs before attempting to restart failed test jobs.
 echo "Running automatic closing of duplicate rebase PRs..."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## MicroShift CI Doctor - Enable Automated Bug Creation and Add Report Refresh

**Changes**: Updates the MicroShift CI Doctor automated workflow script to enable production bug creation and add a new report refresh capability.

**What's affected**: The CI step configuration for the MicroShift CI Doctor, which is part of the OpenShift edge-tooling CI infrastructure in the openshift/release repository.

**Key improvements**:

1. **Automated Bug Creation Enabled**: Modifies the `microshift-ci:create-bugs` plugin invocation to add the `--create --auto` flags (line 254), transitioning from dry-run mode to actively creating bugs in Jira. This allows the CI Doctor to automatically file issues for discovered problems without manual intervention.

2. **New Report Refresh Phase**: Adds a new Claude workflow step that runs the `microshift-ci:doctor-refresh` command with a 5-minute timeout and 30 turns (lines 258-267). This refreshes the HTML report after bugs are created to reflect the updated information in the final output.

3. **Enhanced Logging**: Introduces a new log file `CLAUDE_REPORT_REFRESH_LOG` (line 14) to track the report refresh phase, and updates the exit handler to verify successful completion of all three Claude workflow phases: analysis, bug creation, and report refresh (line 46).

**Timing adjustments**:
- Analysis phase: Explicit timeout set to 2700 seconds (45 minutes)
- Bug creation phase: Maintains 600 seconds (10 minutes) with 50 turns
- New refresh phase: 300 seconds (5 minutes) with 30 turns

**Impact**: Enhances automation in MicroShift's CI pipeline by enabling the CI Doctor to autonomously create Jira bugs for detected issues, reducing manual triage overhead, while ensuring reports are up-to-date with the newly created bugs.

**Note**: The associated Jira issue [USHIFT-6935](https://redhat.atlassian.net/browse/USHIFT-6935) currently lacks a target version assignment; a version of 5.0.0 is expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[USHIFT-6935]: https://redhat.atlassian.net/browse/USHIFT-6935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ