### PR TITLE
NETOBSERV-2635: Update Instance Types

### DIFF
--- a/ci-operator/config/netobserv/netobserv-perf-tests/netobserv-netobserv-perf-tests-main__netobserv-aws-4.22-nightly-x86.yaml
+++ b/ci-operator/config/netobserv/netobserv-perf-tests/netobserv-netobserv-perf-tests-main__netobserv-aws-4.22-nightly-x86.yaml
@@ -58,7 +58,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       CHANGE_POINT_REPOS: kube-burner/kube-burner,kube-burner/kube-burner-ocp,cloud-bulldozer/ingress-perf,cloud-bulldozer/e2e-benchmarking,cloud-bulldozer/orion,openshift/release
       COMPUTE_NODE_REPLICAS: "25"
-      COMPUTE_NODE_TYPE: m6i.4xlarge
+      COMPUTE_NODE_TYPE: m6a.2xlarge
       DISPLAY: noo_bundle_info
       ES_BENCHMARK_INDEX: prod-netobserv-datapoints*
       ES_METADATA_INDEX: perf_scale_ci*
@@ -69,7 +69,6 @@ tests:
       LOKISTACK_SIZE: 1x.small
       LOOKBACK: "30"
       LOOKBACK_SIZE: "15"
-      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       ORION_CONFIG: https://raw.githubusercontent.com/netobserv/netobserv-perf-tests/refs/heads/main/scripts/queries/netobserv-orion.yaml
       ORION_ENVS: PLATFORM=AWS,WORKERS=25,WORKLOAD=node-density-heavy,deployment_model=Kafka
       PATCH_EBPFAGENT_IMAGE: "false"
@@ -107,7 +106,7 @@ tests:
       ACK_FILE: https://raw.githubusercontent.com/netobserv/netobserv-perf-tests/refs/heads/main/scripts/orion/ack.yaml
       BASE_DOMAIN: qe.devcluster.openshift.com
       COMPUTE_NODE_REPLICAS: "25"
-      COMPUTE_NODE_TYPE: m6i.4xlarge
+      COMPUTE_NODE_TYPE: m6a.2xlarge
       DEPLOYMENT_MODEL: Service
       DISPLAY: noo_bundle_info
       ES_BENCHMARK_INDEX: prod-netobserv-datapoints*
@@ -119,7 +118,6 @@ tests:
       LOKI_OPERATOR: None
       LOOKBACK: "30"
       LOOKBACK_SIZE: "15"
-      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       ORION_CONFIG: https://raw.githubusercontent.com/netobserv/netobserv-perf-tests/refs/heads/main/scripts/queries/netobserv-orion-node-density-heavy-service.yaml
       ORION_ENVS: PLATFORM=AWS,WORKERS=25,WORKLOAD=node-density-heavy,deployment_model=Service
       PATCH_EBPFAGENT_IMAGE: "false"
@@ -158,7 +156,7 @@ tests:
       BASE_DOMAIN: qe.devcluster.openshift.com
       CHANGE_POINT_REPOS: kube-burner/kube-burner,kube-burner/kube-burner-ocp,cloud-bulldozer/ingress-perf,cloud-bulldozer/e2e-benchmarking,cloud-bulldozer/orion,openshift/release
       COMPUTE_NODE_REPLICAS: "250"
-      COMPUTE_NODE_TYPE: m6i.4xlarge
+      COMPUTE_NODE_TYPE: m6a.2xlarge
       DISPLAY: noo_bundle_info
       ES_BENCHMARK_INDEX: prod-netobserv-datapoints*
       ES_METADATA_INDEX: perf_scale_ci*
@@ -171,7 +169,6 @@ tests:
       LOKISTACK_SIZE: 1x.medium
       LOOKBACK: "60"
       LOOKBACK_SIZE: "15"
-      OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge
       ORION_CONFIG: https://raw.githubusercontent.com/netobserv/netobserv-perf-tests/refs/heads/main/scripts/queries/netobserv-orion.yaml
       ORION_ENVS: PLATFORM=AWS,WORKERS=250,WORKLOAD=cluster-density-v2,deployment_model=Kafka
       PATCH_EBPFAGENT_IMAGE: "false"


### PR DESCRIPTION
PR changes:

- Remove redundant OPENSHIFT_INFRA_NODE_INSTANCE_TYPE: r5.4xlarge env var since thats the default
- Use COMPUTE_NODE_TYPE: m6a.2xlarge for all NetObserv perf jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Instance Type Updates for NetObserv Performance Tests

This PR updates the AWS EC2 instance type configuration for the NetObserv repository's CI performance test jobs in the OpenShift release repository.

### Changes Made

**Removed redundant infrastructure node instance type setting**: The `OPENSHIFT_INFRA_NODE_INSTANCE_TYPE` environment variable (which was set to `r5.4xlarge`) has been removed from all three test job definitions, as this matches the default value and is unnecessary to explicitly set.

**Updated compute node instance types**: 
- `node-density-heavy-25nodes` (daily job): Downsized from `m6i.4xlarge` to `m6i.2xlarge`
- `cluster-density-v2-250nodes` (weekly cron job): Changed from `m6i.4xlarge` to `m6a.2xlarge`
- `node-density-heavy-25nodes-service-without-loki` (weekly job): No compute type change

These changes optimize the instance types used for NetObserv's performance testing infrastructure, reducing costs while maintaining appropriate test capacity for the workloads.

**Affected repository**: netobserv/netobserv-perf-tests (via CI configuration in the OpenShift release repo)

**Related issue**: [NETOBSERV-2635](https://redhat.atlassian.net/browse/NETOBSERV-2635)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[NETOBSERV-2635]: https://redhat.atlassian.net/browse/NETOBSERV-2635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ