### PR TITLE
[dnm] rehearse: node-density-heavy-24nodes for 4.21/4.22

### DIFF
--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
@@ -136,8 +136,8 @@ tests:
     - ref: openshift-qe-perfscale-aws-data-path-sg
     - chain: openshift-qe-data-path-tests
     workflow: rosa-aws-sts
-- always_run: false
-  as: node-density-heavy-24nodes
+- as: node-density-heavy-24nodes
+  cron: 0 2 * * 3
   reporter_config:
     channel: '#ocp-qe-scale-ci-results'
     job_states_to_report:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml
@@ -153,7 +153,7 @@ tests:
     cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
-      CHANNEL_GROUP: nightly
+      CHANNEL_GROUP: candidate
       COMPUTE_MACHINE_TYPE: m6i.xlarge
       ENABLE_AUTOSCALING: "false"
       INDEX_ENABLED: "true"

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-nightly-x86.yaml
@@ -161,8 +161,8 @@ tests:
     - ref: openshift-qe-perfscale-aws-data-path-sg
     - chain: openshift-qe-data-path-tests
     workflow: rosa-aws-sts
-- always_run: false
-  as: node-density-heavy-24nodes
+- as: node-density-heavy-24nodes
+  cron: 0 2 * * 3
   reporter_config:
     channel: '#ocp-qe-scale-ci-results'
     job_states_to_report:

--- a/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-nightly-x86.yaml
+++ b/ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.22-nightly-x86.yaml
@@ -178,7 +178,7 @@ tests:
     cluster_profile: aws-perfscale
     env:
       ADDITIONAL_WORKER_NODES: "21"
-      CHANNEL_GROUP: nightly
+      CHANNEL_GROUP: candidate
       COMPUTE_MACHINE_TYPE: m6i.xlarge
       ENABLE_AUTOSCALING: "false"
       INDEX_ENABLED: "true"


### PR DESCRIPTION
- **rehearse: trigger node-density-heavy-24nodes for 4.21 and 4.22**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This PR updates ci-operator configuration for the openshift-eng/ocp-qe-perfscale-ci repository to add scheduled rehearse triggers for the node-density-heavy-24nodes perfscale test on ROSA OpenShift 4.21 and 4.22.

Practical changes:
- Files modified: ci-operator/config/openshift-eng/ocp-qe-perfscale-ci/openshift-eng-ocp-qe-perfscale-ci-main__rosa-4.21-nightly-x86.yaml and ...__rosa-4.22-nightly-x86.yaml.
- For both 4.21 and 4.22 the node-density-heavy-24nodes test:
  - removed the explicit always_run: false entry (i.e., it is no longer listed as an always-run job),
  - gained a scheduled trigger: cron: 0 2 * * 3 (runs Wednesdays at 02:00 UTC),
  - updated CHANNEL_GROUP in the test’s env to candidate (was nightly), and
  - remains configured to use the aws-perfscale cluster profile, run the rosa-aws-sts workflow, and report to `#ocp-qe-scale-ci-results` on success/failure/error.

Impact:
- Enables automated weekly perfscale rehearsals for the node-density-heavy-24nodes workload on ROSA 4.21 and 4.22, targeting candidate channel builds and reporting results to the existing Slack channel. No exported/public API changes — configuration-only edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->