### PR TITLE
SREP-4863: Skip sig-storage tests failing on HCP 5.0 nightly

### DIFF
--- a/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
+++ b/ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml
@@ -33,7 +33,9 @@ workflow:
         CSI Mock volume expansion Expansion with recovery should allow recovery if controller expansion fails with final error\|
         cloud-provider-aws-e2e.*loadbalancer NLB internal should be reachable with hairpinning traffic\|
         cloud-provider-aws-e2e.*loadbalancer NLB should be reachable with target-node-labels\|
-        Monitor:apiserver-incluster-availability.*monitor test apiserver-incluster-availability
+        Monitor:apiserver-incluster-availability.*monitor test apiserver-incluster-availability\|
+        MutableCSINodeAllocatableCount.*Attach Limit Exceeded should transition pod to failed state\|
+        PersistentVolumes-local.*blockfswithformat.*Two pods mounting a local volume one after the other
     pre:
       - chain: rosa-aws-sts-hcp-provision
       - ref: osd-ccs-conf-idp-htpasswd-multi-users


### PR DESCRIPTION
## Summary
- Skip-list 2 sig-storage conformance tests persistently failing on HCP 5.0 nightly payload since May 13
- MutableCSINodeAllocatableCount (Beta FeatureGate, not applicable to HCP topology)
- PersistentVolumes-local blockfswithformat

## Upstream Bugs
- openshift/origin#31177
- openshift/origin#31178

Jira: https://redhat.atlassian.net/browse/SREP-4863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change updates the OpenShift CI configuration in the openshift/release repository to relax conformance gating for ROSA hosted control plane (HCP) nightly runs. It modifies the rosa-aws-hcp-conformance workflow (ci-operator/step-registry/rosa/aws/hcp/conformance/rosa-aws-hcp-conformance-workflow.yaml) by extending the TEST_SKIPS list used during conformance runs to skip two sig-storage tests that have been persistently failing on ROSA HCP 5.0 nightly payloads:

- MutableCSINodeAllocatableCount — "Attach Limit Exceeded should transition pod to failed state" (Beta FeatureGate, not applicable to HCP topology; upstream issue: openshift/origin#31177)
- PersistentVolumes-local — "blockfswithformat Two pods mounting a local volume one after the other" (upstream issue: openshift/origin#31178)

The change also normalizes the multiline TEST_SKIPS formatting (adds/adjusts separators for consistency). No code or public API changes — only CI workflow configuration so nightly ROSA HCP conformance runs are not blocked by these payload-related regressions while upstream fixes proceed. The PR references Jira [SREP-4863](https://redhat.atlassian.net/browse/SREP-4863).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[SREP-4863]: https://redhat.atlassian.net/browse/SREP-4863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ