### PR TITLE
HYPERFLEET-1079 - chore: bump hooks version

### DIFF
--- a/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh
+++ b/ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh
@@ -9,7 +9,7 @@ if [ -z "${PULL_BASE_SHA:-}" ]; then
     exit 1
 fi
 
-HOOKS_VERSION="v0.1.3"
+HOOKS_VERSION="v0.2.0"
 HOOKS_URL="https://github.com/openshift-hyperfleet/hyperfleet-hooks/releases/download/${HOOKS_VERSION}/hyperfleet-hooks-linux-amd64"
 HOOKS_BIN="/tmp/hyperfleet-hooks"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Updates HyperFleet commitlint validation tool version

Bumps the `hyperfleet-hooks` binary version used in HyperFleet component repositories' CI pipelines from `v0.1.3` to `v0.2.0`. 

This change affects the commit message validation that runs as a presubmit check across all OpenShift HyperFleet repositories (hyperfleet-adapter, hyperfleet-api, hyperfleet-broker, hyperfleet-credential-provider, hyperfleet-sentinel, and others). The `hyperfleet-hooks commitlint` validation step will now download and execute the newer version of the validation tool when PRs are submitted to these repositories.

**Modified file:**
- `ci-operator/step-registry/hyperfleet/commitlint/hyperfleet-commitlint-commands.sh`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->