### PR TITLE
neuron-ci: fix RHOAI channel for 4.19/4.20 KServe tests

### DIFF
--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml
@@ -106,7 +106,7 @@ tests:
       OCM_LOGIN_ENV: production
       OPENSHIFT_VERSION: "4.19"
       REGION: us-west-2
-      RHOAI_CHANNEL: stable-3.x
+      RHOAI_CHANNEL: stable
       VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
     workflow: aws-neuron-operator-kserve-e2e-rosa
 - as: aws-neuron-operator-kserve-e2e-weekly
@@ -127,7 +127,7 @@ tests:
       OCM_LOGIN_ENV: production
       OPENSHIFT_VERSION: "4.19"
       REGION: us-west-2
-      RHOAI_CHANNEL: stable-3.x
+      RHOAI_CHANNEL: stable
       VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
     workflow: aws-neuron-operator-kserve-e2e-rosa
 zz_generated_metadata:

--- a/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
+++ b/ci-operator/config/rh-ecosystem-edge/neuron-ci/rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml
@@ -107,7 +107,7 @@ tests:
       OCM_LOGIN_ENV: production
       OPENSHIFT_VERSION: "4.20"
       REGION: us-west-2
-      RHOAI_CHANNEL: stable-3.x
+      RHOAI_CHANNEL: stable
       VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
     workflow: aws-neuron-operator-kserve-e2e-rosa
 - as: aws-neuron-operator-kserve-e2e-weekly
@@ -128,7 +128,7 @@ tests:
       OCM_LOGIN_ENV: production
       OPENSHIFT_VERSION: "4.20"
       REGION: us-west-2
-      RHOAI_CHANNEL: stable-3.x
+      RHOAI_CHANNEL: stable
       VLLM_NEURON_IMAGE: registry.redhat.io/rhaiis/vllm-neuron-rhel9:3
     workflow: aws-neuron-operator-kserve-e2e-rosa
 zz_generated_metadata:


### PR DESCRIPTION
## Summary
- Fix KServe test failures on OCP 4.19 and 4.20 by changing `RHOAI_CHANNEL` from `stable-3.x` to `stable`
- OCP < 4.21 uses Serverless mode (SM2 + KNative) which requires RHOAI 2.x (`stable` channel)
- RHOAI 3.x (`stable-3.x`) retired Serverless mode entirely and never creates KnativeServing, causing the `install-kserve-deps` step to timeout waiting for the `knative-serving/config-deployment` configmap
- OCP 4.21 config is unaffected — it correctly uses `stable-3.x` with RawDeployment mode

## Failure reference
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-rh-ecosystem-edge-neuron-ci-main-4.19-stable-aws-neuron-operator-kserve-e2e-weekly/2054804162608107520

## Test plan
- [ ] CI passes ci-operator-config-metadata check
- [ ] Next 4.19 kserve-e2e-weekly periodic run installs RHOAI 2.x and completes KNative Serving setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes RHOAI (Red Hat OpenShift AI) channel configuration for the AWS Neuron operator's KServe E2E test suites on OCP 4.19 and 4.20.

### Changes

Updates the CI test environment configuration for the neuron-ci repository by changing the `RHOAI_CHANNEL` environment variable from `stable-3.x` to `stable` in the following CI configuration files:
- `rh-ecosystem-edge-neuron-ci-main__4.19-stable.yaml` (2 test variants updated)
- `rh-ecosystem-edge-neuron-ci-main__4.20-stable.yaml` (2 test variants updated)

### Rationale

OCP versions prior to 4.21 require Serverless mode (SM2 + Knative) for KServe, which depends on RHOAI 2.x (available via the `stable` channel). RHOAI 3.x (`stable-3.x` channel) removed Serverless mode support and no longer creates the KnativeServing component. This caused the `install-kserve-deps` test step to time out while waiting for the `knative-serving/config-deployment` configmap.

OCP 4.21 configuration is not affected and continues using `stable-3.x` with RawDeployment mode.

### Expected Impact

The updated CI jobs for 4.19 and 4.20 KServe E2E tests will now install the correct RHOAI 2.x version, allowing the Knative Serving setup to complete successfully and resolving the test timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->