### PR TITLE
fix: enforce CI gates for operator-framework repos

### DIFF
--- a/core-services/prow/02_config/operator-framework/api/_prowconfig.yaml
+++ b/core-services/prow/02_config/operator-framework/api/_prowconfig.yaml
@@ -5,6 +5,7 @@ branch-protection:
         api:
           branches:
             master:
+              enforce_admins: true
               protect: true
               required_status_checks:
                 contexts:

--- a/core-services/prow/02_config/operator-framework/operator-controller/_prowconfig.yaml
+++ b/core-services/prow/02_config/operator-framework/operator-controller/_prowconfig.yaml
@@ -1,3 +1,12 @@
+branch-protection:
+  orgs:
+    operator-framework:
+      repos:
+        operator-controller:
+          branches:
+            main:
+              enforce_admins: true
+              protect: true
 tide:
   merge_method:
     operator-framework/operator-controller: squash

--- a/core-services/prow/02_config/operator-framework/operator-lifecycle-manager/_prowconfig.yaml
+++ b/core-services/prow/02_config/operator-framework/operator-lifecycle-manager/_prowconfig.yaml
@@ -1,3 +1,12 @@
+branch-protection:
+  orgs:
+    operator-framework:
+      repos:
+        operator-lifecycle-manager:
+          branches:
+            master:
+              enforce_admins: true
+              protect: true
 tide:
   merge_method:
     operator-framework/operator-lifecycle-manager: squash

--- a/core-services/prow/02_config/operator-framework/operator-registry/_prowconfig.yaml
+++ b/core-services/prow/02_config/operator-framework/operator-registry/_prowconfig.yaml
@@ -1,3 +1,12 @@
+branch-protection:
+  orgs:
+    operator-framework:
+      repos:
+        operator-registry:
+          branches:
+            master:
+              enforce_admins: true
+              protect: true
 tide:
   merge_method:
     operator-framework/operator-registry: squash


### PR DESCRIPTION
Four operator-framework repos (api, operator-controller, operator-lifecycle-manager, operator-registry) could have PRs merged before CI completed due to two compounding gaps:

1. skip-unknown-contexts: true caused Tide to treat GitHub Actions checks as optional, allowing label-only merge approval.
2. enforce_admins: false (GitHub) exempted the openshift-merge-bot from required status checks, letting it push even with pending CI.

Both gaps were confirmed to have caused a real merge without CI on operator-lifecycle-manager today (PR #3830).

Fixes:
- Add enforce_admins: true to branch-protection for all four repos, bringing the GitHub-enforced setting under IaC/code-review control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Prevent accidental merges before CI completes for four operator-framework repositories by enabling GitHub admin enforcement in branch protection.
  - Repositories and branches affected:
    - operator-framework/api — master (protect: true, enforce_admins: true; required_status_checks include verify, Build)
    - operator-framework/operator-controller — main (protect: true, enforce_admins: true)
    - operator-framework/operator-lifecycle-manager — master (protect: true, enforce_admins: true)
    - operator-framework/operator-registry — master (protect: true, enforce_admins: true)
* Context: previously Tide treated GitHub Actions checks as optional when skip-unknown-contexts: true and branch protection had enforce_admins: false, allowing the openshift-merge-bot to bypass required status checks; this change ensures the GitHub-managed enforce_admins setting is controlled via code review/infrastructure-as-code so merges cannot complete before required CI checks finish.

All changes are configuration-only updates to Prow/_prowconfig.yaml files; no runtime code or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->