### PR TITLE
Update golang to 1.25 in OLS tests

### DIFF
--- a/ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main.yaml
+++ b/ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.22
 images:
   items:
   - dockerfile_path: prow/Dockerfile

--- a/ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main__mcp.yaml
+++ b/ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main__mcp.yaml
@@ -2,7 +2,7 @@ build_root:
   image_stream_tag:
     name: release
     namespace: openshift
-    tag: rhel-9-release-golang-1.24-openshift-4.22
+    tag: rhel-9-release-golang-1.25-openshift-4.22
 releases:
   latest:
     candidate:


### PR DESCRIPTION
### Description
Updating to golang 1.25 to fix the current CI. Context [here](https://redhat-internal.slack.com/archives/C08DG2UL422/p1778247746062259)

### Testing
Will be testing through the rehearsals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Golang Version Update for OLS Load Generator Tests

This PR updates the Go version used in the OpenShift OLS load generator's CI/test environment from Go 1.24 to Go 1.25.

## Changes

Two OpenShift CI operator configuration files for the OLS load generator were updated:
- `ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main.yaml`
- `ci-operator/config/openshift/ols-load-generator/openshift-ols-load-generator-main__mcp.yaml`

In both files, the `build_root.image_stream_tag` was updated from `rhel-9-release-golang-1.24-openshift-4.22` to `rhel-9-release-golang-1.25-openshift-4.22`. This ensures that test builds and load generator tests will use the newer Go 1.25 runtime. All other pipeline configurations—including build targets, promotion settings, resource allocations, and test job definitions—remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->