### PR TITLE
scaling rhoe 4.15/4.17 to zero due to eol

### DIFF
--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-15-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-15-amd64-aws-us-east-1_clusterpool.yaml
@@ -32,7 +32,7 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0

--- a/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-17-amd64-aws-us-west-1_clusterpool.yaml
+++ b/clusters/hosted-mgmt/hive/pools/rh-openshift-ecosystem/rhoe-ocp-4-17-amd64-aws-us-west-1_clusterpool.yaml
@@ -32,7 +32,7 @@ spec:
       region: us-west-1
   pullSecretRef:
     name: pull-secret
-  size: 1
+  size: 0
   skipMachinePools: true
 status:
   ready: 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR decommissions two end-of-life OpenShift versions from the Red Hat OpenShift Ecosystem (RHOE) CI infrastructure by scaling their cluster pools to zero.

## Changes

The `spec.size` configuration is reduced from `1` to `0` in two RHOE cluster pool manifests:
- **rhoe-ocp-4-15-amd64-aws-us-east-1**: OpenShift 4.15 cluster pool in US East region
- **rhoe-ocp-4-17-amd64-aws-us-west-1**: OpenShift 4.17 cluster pool in US West region

## Impact

By setting pool size to zero, these changes:
- Prevent new cluster provisioning from these pools
- Stop maintaining standing/pre-warmed clusters for these versions
- Reduce infrastructure costs and resource consumption for EOL versions
- Allow cluster resources to be freed for active, supported OpenShift versions

These cluster pools are managed by Hive (a component of the OpenShift CI infrastructure) and are used for certification testing and ecosystem validation. The pools are part of the `rhoe-cluster-pool` namespace within the hosted management cluster that powers OpenShift's continuous integration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->