### PR TITLE
OCPBUGS-85533: Manual-oidc workflows to skip the sig-cluster-lifecycle CSRs test

### DIFF
--- a/ci-operator/step-registry/openshift/e2e/aws/manual-oidc-sts/openshift-e2e-aws-manual-oidc-sts-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/aws/manual-oidc-sts/openshift-e2e-aws-manual-oidc-sts-workflow.yaml
@@ -1,6 +1,9 @@
 workflow:
   as: openshift-e2e-aws-manual-oidc-sts
   steps:
+    env:
+      TEST_SKIPS: >-
+        CSRs from machines that are not recognized by the cloud provider are not approved
     pre:
     - chain: ipi-aws-pre-manual-oidc-sts
     test:

--- a/ci-operator/step-registry/openshift/e2e/azure/manual-oidc-workload-identity/openshift-e2e-azure-manual-oidc-workload-identity-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/azure/manual-oidc-workload-identity/openshift-e2e-azure-manual-oidc-workload-identity-workflow.yaml
@@ -1,6 +1,9 @@
 workflow:
   as: openshift-e2e-azure-manual-oidc-workload-identity
   steps:
+    env:
+      TEST_SKIPS: >-
+        CSRs from machines that are not recognized by the cloud provider are not approved
     pre:
     - chain: ipi-azure-pre-manual-oidc-workload-identity
     test:

--- a/ci-operator/step-registry/openshift/e2e/gcp/manual-oidc-workload-identity/openshift-e2e-gcp-manual-oidc-workload-identity-workflow.yaml
+++ b/ci-operator/step-registry/openshift/e2e/gcp/manual-oidc-workload-identity/openshift-e2e-gcp-manual-oidc-workload-identity-workflow.yaml
@@ -1,6 +1,9 @@
 workflow:
   as: openshift-e2e-gcp-manual-oidc-workload-identity
   steps:
+    env:
+      TEST_SKIPS: >-
+        CSRs from machines that are not recognized by the cloud provider are not approved
     pre:
     - chain: ipi-gcp-pre-manual-oidc-workload-identity
     test:


### PR DESCRIPTION
The test for "CSRs from machines that are not recognized by the cloud provider are not approved" has the service account issuer hard coded. In manual oidc configuration, it no longer matches the service account issuer of the cluster, so the test fails. We are opting to skip this test for the manual-oidc workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the OpenShift CI infrastructure to prevent test failures in manual OIDC workflows by skipping a certificate signing request (CSR) validation test that is incompatible with manual OIDC configurations.

## Changes

The PR modifies three manual OIDC end-to-end test workflows across different cloud providers:

- **AWS**: `ci-operator/step-registry/openshift/e2e/aws/manual-oidc-sts/openshift-e2e-aws-manual-oidc-sts-workflow.yaml`
- **Azure**: `ci-operator/step-registry/openshift/e2e/azure/manual-oidc-workload-identity/openshift-e2e-azure-manual-oidc-workload-identity-workflow.yaml`
- **GCP**: `ci-operator/step-registry/openshift/e2e/gcp/manual-oidc-workload-identity/openshift-e2e-gcp-manual-oidc-workload-identity-workflow.yaml`

Each workflow now configures a `TEST_SKIPS` environment variable that instructs the test suite to skip the sig-cluster-lifecycle CSR validation test ("CSRs from machines that are not recognized by the cloud provider are not approved").

## Motivation

The skipped test relies on a hard-coded service account issuer value that no longer matches the dynamically-configured issuer used in manual OIDC setups, causing the test to fail. Rather than updating the test itself, the workflows are configured to skip this test during manual OIDC CI runs, allowing other test coverage to proceed without blockage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->