### PR TITLE
Disable OCS environment checker on OPP vSphere 4.22 job

### DIFF
--- a/ci-operator/config/stolostron/policy-collection/stolostron-policy-collection-main__ocp4.22.yaml
+++ b/ci-operator/config/stolostron/policy-collection/stolostron-policy-collection-main__ocp4.22.yaml
@@ -145,6 +145,7 @@ tests:
     cluster_profile: vsphere-connected-2
     env:
       COMPUTE_NODE_REPLICAS: "6"
+      DISABLE_ENVIRONMENT_CHECKER: "true"
       FIREWATCH_CONFIG_FILE_PATH: https://raw.githubusercontent.com/CSPI-QE/cspi-utils/refs/heads/main/firewatch-base-configs/opp/lp-interop-vsphere.json
       FIREWATCH_DEFAULT_JIRA_ADDITIONAL_LABELS: '["4.22-lp","opp-vsphere-lp","opp-lp"]'
       FIREWATCH_DEFAULT_JIRA_ASSIGNEE: ftan@redhat.com

--- a/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
+++ b/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
@@ -120,6 +120,10 @@ ENV_DATA:
 __APPENDED_ENV_DATA__
 fi
 
+EXTRA_ARGS=""
+if [[ "${DISABLE_ENVIRONMENT_CHECKER}" == "true" ]]; then
+    EXTRA_ARGS="--disable-environment-checker"
+fi
 
 set -x
 START_TIME=$(date "+%s")
@@ -133,6 +137,7 @@ run-ci --color=yes -o cache_dir=/tmp tests/ -m 'acceptance and not ui' -k '' \
   --cluster-name "${CLUSTER_NAME}"                   \
   --html         "${CLUSTER_PATH}/test-results.html" \
   --junit-xml    "${CLUSTER_PATH}/junit.xml"         \
+  ${EXTRA_ARGS} \
   || /bin/true
 
 
@@ -148,8 +153,8 @@ cp "${CLUSTER_PATH}/junit.xml" "${SHARED_DIR}"
 
 if [[ ${DIFF_TIME} -le 1800 ]]; then
     echo ""
-    echo " 🚨  The tests finished too quickly (took only: ${DIFF_TIME} sec), pausing here to give us time to debug"
-    echo "  😴 😴 😴"
+    echo " \xF0\x9F\x9A\xA8  The tests finished too quickly (took only: ${DIFF_TIME} sec), pausing here to give us time to debug"
+    echo "  \xF0\x9F\x98\xB4 \xF0\x9F\x98\xB4 \xF0\x9F\x98\xB4"
     sleep 7200
     exit 1
 else

--- a/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
+++ b/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-commands.sh
@@ -153,8 +153,8 @@ cp "${CLUSTER_PATH}/junit.xml" "${SHARED_DIR}"
 
 if [[ ${DIFF_TIME} -le 1800 ]]; then
     echo ""
-    echo " \xF0\x9F\x9A\xA8  The tests finished too quickly (took only: ${DIFF_TIME} sec), pausing here to give us time to debug"
-    echo "  \xF0\x9F\x98\xB4 \xF0\x9F\x98\xB4 \xF0\x9F\x98\xB4"
+    echo " 🚨  The tests finished too quickly (took only: ${DIFF_TIME} sec), pausing here to give us time to debug"
+    echo "  😴 😴 😴"
     sleep 7200
     exit 1
 else

--- a/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-ref.yaml
+++ b/ci-operator/step-registry/interop-tests/ocs-tests/interop-tests-ocs-tests-ref.yaml
@@ -20,4 +20,6 @@ ref:
   - name: REPORTPORTAL_CMP
     default: "CNV-lp-interop"
     documentation: If test mapping is applied, differentiate between the CNV and ODF jobs
-
+  - name: DISABLE_ENVIRONMENT_CHECKER
+    default: "false"
+    documentation: If true, skip the OCS environment checker during teardown


### PR DESCRIPTION
## Summary

The OCS `environment_check` teardown flags non-ODF PVs (Quay PVCs provisioned by `csi.vsphere.vmware.com`) as test leftovers, causing 100% of OCS test runs to fail on vSphere with `ResourceLeftoversException` even though all tests pass.

This adds a `DISABLE_ENVIRONMENT_CHECKER` env var (default `false`) to the `interop-tests-ocs-tests` step, and enables it for the OPP vSphere 4.22 job as a workaround until the upstream fix lands.

## Changes

| File | Change |
|------|--------|
| `interop-tests-ocs-tests-ref.yaml` | Add `DISABLE_ENVIRONMENT_CHECKER` env var (default `false`) |
| `interop-tests-ocs-tests-commands.sh` | Conditionally append `--disable-environment-checker` to `run-ci` |
| `stolostron-policy-collection-main__ocp4.22.yaml` | Set `DISABLE_ENVIRONMENT_CHECKER: true` for `interop-opp-vsphere` |

## Why

- Only the vSphere job is affected (Quay uses `csi.vsphere.vmware.com` PVs on vSphere; on AWS these are EBS-backed and don't trigger the issue)
- The env var approach is opt-in; other OPP jobs (AWS, GCP) keep the environment checker enabled
- When [ocs-ci#15158](https://github.com/red-hat-storage/ocs-ci/issues/15158) is fixed upstream, we remove the env override

## References

- Jira: [OCSQE-4715](https://redhat.atlassian.net/browse/OCSQE-4715)
- Upstream fix: [red-hat-storage/ocs-ci#15158](https://github.com/red-hat-storage/ocs-ci/issues/15158)
- Workaround suggested by ODF QE (Jilju Joy) on the Jira ticket

[OCSQE-4715]: https://redhat.atlassian.net/browse/OCSQE-4715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR introduces a temporary workaround for a vSphere-specific issue in the OpenShift CI infrastructure where the OCS environment checker incorrectly flags non-ODF storage provisioned by platform CSI drivers (e.g., Quay's Ceph RBD PVCs from csi.vsphere.vmware.com) as leftover resources during teardown, causing test-run failures despite passing tests.

## Changes

The PR adds an opt-in mechanism to disable the OCS environment checker for interop test runs:

1. **interop-tests-ocs-tests-ref.yaml**: Introduces a new `DISABLE_ENVIRONMENT_CHECKER` environment variable (default: `false`) that controls whether the OCS environment checker is skipped during teardown.

2. **interop-tests-ocs-tests-commands.sh**: Updates the OCS test execution script to conditionally append the `--disable-environment-checker` flag to the `run-ci` command when the environment variable is set to `true`.

3. **stolostron-policy-collection-main__ocp4.22.yaml**: Enables the workaround specifically for the `interop-opp-vsphere` job by setting `DISABLE_ENVIRONMENT_CHECKER: "true"`.

## Impact

This change is localized to the OPP vSphere 4.22 CI job. Other OPP jobs (AWS, GCP) remain unaffected. The workaround is temporary and will be removed once the upstream fix (red-hat-storage/ocs-ci#15158) is merged, which will make the environment checker properly filter resources by provisioner annotation to exclude non-ODF CSI drivers.

## Related Issue

This addresses the vSphere environment check issue ([OCSQE-4715](https://redhat.atlassian.net/browse/OCSQE-4715)) where the checker needs to distinguish between ODF-managed storage and other platform provisioned resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->