### PR TITLE
Fix OO_INSTALL_MODE not passed to operator-sdk run bundle

### DIFF
--- a/ci-operator/step-registry/optional-operators/operator-sdk/optional-operators-operator-sdk-commands.sh
+++ b/ci-operator/step-registry/optional-operators/operator-sdk/optional-operators-operator-sdk-commands.sh
@@ -53,7 +53,7 @@ fi
 
 INSTALL_MODE_ARG=""
 if [[ -n ${OO_INSTALL_MODE} ]]; then
-  INSTALL_MODE_ARG=--install-mode="${INSTALL_MODE_ARG}"
+  INSTALL_MODE_ARG=--install-mode="${OO_INSTALL_MODE}"
 fi
 (
   cd /tmp


### PR DESCRIPTION
## Summary

Fix bug in `optional-operators-operator-sdk-commands.sh` where `INSTALL_MODE_ARG` self-references (empty string) instead of reading `OO_INSTALL_MODE`. This causes `--install-mode=""` to always be passed to `operator-sdk run bundle`, ignoring the configured install mode.

**Before:** `INSTALL_MODE_ARG=--install-mode="${INSTALL_MODE_ARG}"` (always empty)
**After:** `INSTALL_MODE_ARG=--install-mode="${OO_INSTALL_MODE}"` (reads env var)

## Impact

Any CI config setting `OO_INSTALL_MODE` (e.g., `OwnNamespace`) was silently ignored. This fix is needed for:
- openshift/release#79152 — OADP FBC migration setting `OO_INSTALL_MODE: OwnNamespace`
- openshift/oadp-operator#2160 — OLMv1 lifecycle tests requiring OwnNamespace install mode

> [!Note]
> Responses generated with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes a bug in the OpenShift CI optional-operators step script so the OO_INSTALL_MODE environment variable is actually passed to operator-sdk. The script is used by the openshift/release CI to run optional operator bundle tests; previously the install-mode argument was empty and any OO_INSTALL_MODE configured in CI (e.g., OwnNamespace) was ignored.

## Changes

A one-line correction in ci-operator/step-registry/optional-operators/operator-sdk/optional-operators-operator-sdk-commands.sh:
- Before: INSTALL_MODE_ARG was effectively set from itself (resulting in an empty --install-mode).
- After: INSTALL_MODE_ARG is set from OO_INSTALL_MODE:
  INSTALL_MODE_ARG=--install-mode="${OO_INSTALL_MODE}"

## Impact

CI jobs that set OO_INSTALL_MODE (for example to OwnNamespace for OLMv1 lifecycle tests) will now pass that install mode to operator-sdk run bundle. This fixes silent test misconfiguration and is required for related work that depends on non-default install modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->