### PR TITLE
NO-ISSUE: add IBM mirror fix to osac-project cluster-tool workflow

### DIFF
--- a/ci-operator/step-registry/baremetalds/devscripts/ibm/baremetalds-devscripts-ibm-commands.sh
+++ b/ci-operator/step-registry/baremetalds/devscripts/ibm/baremetalds-devscripts-ibm-commands.sh
@@ -10,7 +10,7 @@ echo "************ baremetalds devscripts ibm command ************"
 # shellcheck disable=SC1090
 source "${SHARED_DIR}/packet-conf.sh"
 
-# Removes IBM custom CentOS rpm mirros and uncomments the community mirrors
+# Removes IBM custom rpm mirrors and restores community mirrors (CentOS Stream + Rocky)
 ssh "${SSHOPTS[@]}" "root@${IP}" bash - << EOF
 set +x
 
@@ -18,6 +18,7 @@ for f in /etc/yum.repos.d/*.repo; do
   if grep -q '^baseurl=.*networklayer\.com' "\$f"; then
     sudo sed -i \
       -e '/^#metalink=/s/^#//' \
+      -e '/^#mirrorlist=/s/^#//' \
       -e '/^baseurl=.*networklayer\.com/s/^/#/' \
       "\$f"
   fi

--- a/ci-operator/step-registry/osac-project/cluster-tool/vmaas/osac-project-cluster-tool-vmaas-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/cluster-tool/vmaas/osac-project-cluster-tool-vmaas-workflow.yaml
@@ -6,6 +6,7 @@ workflow:
     allow_skip_on_success: true
     pre:
       - ref: ofcir-acquire
+      - ref: baremetalds-devscripts-ibm
       - ref: osac-project-cluster-tool-boot
     test:
       - ref: osac-project-cluster-tool-test


### PR DESCRIPTION
## Problem

IBM Cloud replaces the default CentOS/Rocky repo configuration on its baremetal hosts with a
non-redundant `baseurl` pointing at `mirrors.service.networklayer.com`. When that mirror goes
down, every `dnf install` on the host fails, killing all jobs that run on IBM Cloud OFCIR machines.

This has happened four times now (Jul 2025, Sep 2025 twice, May 2026). The metal platform team
fixed it for CentOS Stream hosts in [#69644](https://github.com/openshift/release/pull/69644)
(tracking [METAL-1565](https://issues.redhat.com/browse/METAL-1565)) by adding the
`baremetalds-devscripts-ibm` step, which comments out the IBM `baseurl` and uncomments the
community `metalink`.

**However, the `assisted_large_el9` and `assisted_medium_el9` OFCIR pools run Rocky Linux 9,
not CentOS Stream.** Rocky uses `mirrorlist=` instead of `metalink=`, so the existing fix
comments out the IBM baseurl but leaves no working alternative — producing
`"Cannot find a valid baseurl for repo: baseos"`.

This is currently causing mass failures across both OSAC and assisted-service periodic jobs:
- https://github.com/osac-project/osac-installer/pull/99
- `periodic-ci-openshift-assisted-service-master-edge-e2e-ai-operator-ztp-*` (multiple)

## Fix

Two changes:

1. **`baremetalds-devscripts-ibm-commands.sh`**: Add `'/^#mirrorlist=/s/^#//'` to also
   uncomment Rocky Linux mirror lines. This is a no-op on CentOS Stream hosts (they don't
   have `#mirrorlist=` lines).

2. **`osac-project-cluster-tool-vmaas-workflow.yaml`**: Add the `baremetalds-devscripts-ibm`
   step between `ofcir-acquire` and `osac-project-cluster-tool-boot`, matching what the
   `baremetalds-ofcir-pre` chain already does for metal IPI jobs.

## Context

Slack threads documenting the recurring IBM mirror outages:
- [Sep 2025 incident](https://redhat-internal.slack.com/archives/CFP6ST0A3/p1758633749832519)
- [Sep 2025 fix discussion](https://redhat-internal.slack.com/archives/CFP6ST0A3/p1757361180396239)
- [Current incident](https://redhat-internal.slack.com/archives/CBN38N3MW/p1778796059141859)

[METAL-1565]: https://redhat.atlassian.net/browse/METAL-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates OpenShift CI configuration to ensure OSAC VMAAS jobs running on IBM Cloud baremetal hosts restore community CentOS/Rocky metalinks before any package installs.

## What changed

- Inserts the existing baremetalds-devscripts-ibm pre-step into the osac-project-cluster-tool-vmaas workflow (placed between ofcir-acquire and osac-project-cluster-tool-boot).
- Clarifies the step’s intent in its command script: SSH into the acquired host, comment out IBM’s networklayer.com baseurl and un-comment community metalink/mirrorlist lines in /etc/yum.repos.d/*.repo.

Affected CI config: ci-operator workflow ci-operator/step-registry/osac-project/cluster-tool/vmaas/osac-project-cluster-tool-vmaas-workflow.yaml and the step script ci-operator/step-registry/baremetalds/devscripts/ibm/baremetalds-devscripts-ibm-commands.sh.

## Why it matters

IBM Cloud baremetal images replace repo configs with a single non-redundant IBM mirror (mirrors.service.networklayer.com). When that mirror is down (several outages observed), dnf installs fail with 404s and CI jobs on IBM OFCIR machines break. Adding this step ensures the host switches to community metalinks prior to any provisioning installs, avoiding those failures. The step is a no-op on non-IBM hosts.

## Impact

Unblocks downstream work that depended on this fix (e.g., osac-installer PR waiting on CI) and reduces flakes/failures for OSAC VMAAS jobs running on IBM baremetal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->