### PR TITLE
OSAC-865: add Slack notification step for CI jobs

### DIFF
--- a/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
+++ b/ci-operator/config/osac-project/osac-test-infra/osac-project-osac-test-infra-main.yaml
@@ -66,6 +66,12 @@ tests:
   capabilities:
   - intranet
   steps:
+    post:
+    - ref: osac-project-notify
+    - ref: osac-project-gather
+    - ref: osac-project-cluster-tool-destroy
+    - ref: ofcir-gather
+    - ref: ofcir-release
     workflow: osac-project-cluster-tool-vmaas
 - as: e2e-metal-vmaas-compute-instance-creation
   capabilities:

--- a/ci-operator/step-registry/baremetalds/devscripts/ibm/baremetalds-devscripts-ibm-commands.sh
+++ b/ci-operator/step-registry/baremetalds/devscripts/ibm/baremetalds-devscripts-ibm-commands.sh
@@ -10,7 +10,7 @@ echo "************ baremetalds devscripts ibm command ************"
 # shellcheck disable=SC1090
 source "${SHARED_DIR}/packet-conf.sh"
 
-# Removes IBM custom CentOS rpm mirros and uncomments the community mirrors
+# Removes IBM custom rpm mirrors and restores community mirrors (CentOS Stream + Rocky)
 ssh "${SSHOPTS[@]}" "root@${IP}" bash - << EOF
 set +x
 
@@ -18,6 +18,7 @@ for f in /etc/yum.repos.d/*.repo; do
   if grep -q '^baseurl=.*networklayer\.com' "\$f"; then
     sudo sed -i \
       -e '/^#metalink=/s/^#//' \
+      -e '/^#mirrorlist=/s/^#//' \
       -e '/^baseurl=.*networklayer\.com/s/^/#/' \
       "\$f"
   fi

--- a/ci-operator/step-registry/osac-project/cluster-tool/vmaas/osac-project-cluster-tool-vmaas-workflow.yaml
+++ b/ci-operator/step-registry/osac-project/cluster-tool/vmaas/osac-project-cluster-tool-vmaas-workflow.yaml
@@ -6,6 +6,7 @@ workflow:
     allow_skip_on_success: true
     pre:
       - ref: ofcir-acquire
+      - ref: baremetalds-devscripts-ibm
       - ref: osac-project-cluster-tool-boot
     test:
       - ref: osac-project-cluster-tool-test

--- a/ci-operator/step-registry/osac-project/notify/OWNERS
+++ b/ci-operator/step-registry/osac-project/notify/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - osac-cicd
+reviewers:
+  - osac-cicd

--- a/ci-operator/step-registry/osac-project/notify/osac-project-notify-commands.sh
+++ b/ci-operator/step-registry/osac-project/notify/osac-project-notify-commands.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+WEBHOOK_URL="$(cat /var/run/vault/osac-slack-webhook/url)"
+PROW_URL="https://prow.ci.openshift.org/view/gs/test-platform-results"
+
+if [[ "${JOB_TYPE:-}" == "presubmit" ]]; then
+    JOB_URL="${PROW_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+else
+    JOB_URL="${PROW_URL}/logs/${JOB_NAME}/${BUILD_ID}"
+fi
+
+curl -s -X POST -H 'Content-type: application/json' \
+    --data "{\"text\":\"Job *${JOB_NAME}* #${BUILD_ID} completed.\n<${JOB_URL}|View logs>\"}" \
+    "${WEBHOOK_URL}"

--- a/ci-operator/step-registry/osac-project/notify/osac-project-notify-ref.metadata.json
+++ b/ci-operator/step-registry/osac-project/notify/osac-project-notify-ref.metadata.json
@@ -1,0 +1,11 @@
+{
+	"path": "osac-project/notify/osac-project-notify-ref.yaml",
+	"owners": {
+		"approvers": [
+			"osac-cicd"
+		],
+		"reviewers": [
+			"osac-cicd"
+		]
+	}
+}

--- a/ci-operator/step-registry/osac-project/notify/osac-project-notify-ref.yaml
+++ b/ci-operator/step-registry/osac-project/notify/osac-project-notify-ref.yaml
@@ -1,0 +1,16 @@
+ref:
+  as: osac-project-notify
+  best_effort: true
+  from: dev-scripts
+  timeout: 5m0s
+  commands: osac-project-notify-commands.sh
+  credentials:
+  - namespace: test-credentials
+    name: osac-slack-webhook
+    mount_path: /var/run/vault/osac-slack-webhook
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  documentation: |-
+    Sends a Slack notification with the job result and a link to the Prow logs.


### PR DESCRIPTION
## Summary
- Adds `osac-project-notify` step-registry ref that posts job results to Slack via incoming webhook
- Wired into e2e-vmaas presubmit on osac-test-infra for validation — will be moved to periodic jobs after confirming it works

## Test plan
- [ ] Run `/test e2e-vmaas` rehearsal to confirm the webhook fires and Slack message is received

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds Slack notification capability to the OpenShift CI infrastructure by introducing a new `osac-project-notify` step-registry entry. This step posts job completion results to Slack via an incoming webhook, enabling real-time notification of CI job outcomes.

## Changes

**New Slack Notification Step:**
- Created `osac-project-notify` step that reads a Slack webhook URL from Vault (`test-credentials` namespace) and sends job completion notifications
- The script constructs Prow job log links with appropriate URL formatting for presubmit PRs vs. periodic/non-PR jobs
- Configured as a best-effort step with 5-minute timeout, running from the `dev-scripts` base image with minimal resource requests (100m CPU, 200Mi memory)
- Includes OWNERS file and step metadata for proper governance

**Integration:**
- Wired the notification step into the `e2e-vmaas` presubmit test's post-pipeline on the `osac-test-infra` repository for initial validation before broader rollout to periodic jobs
- Updated the `osac-project-cluster-tool-vmaas` workflow to include the `baremetalds-devscripts-ibm` step

**Supporting Changes:**
- Enhanced IBM mirror handling in `baremetalds-devscripts-ibm-commands.sh` to uncomment `mirrorlist=` entries in addition to existing `metalink=` handling, improving compatibility with community mirrors (CentOS Stream + Rocky)

## Testing

The PR includes a test plan to run the `/test e2e-vmaas` rehearsal command to validate that the webhook integration works and Slack messages are successfully delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->