### PR TITLE
Fix OCP CI jobs for Tracing UI and OTEL

### DIFF
--- a/ci-operator/config/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22__upstream-amd64-aws.yaml
+++ b/ci-operator/config/openshift/distributed-tracing-console-plugin/openshift-distributed-tracing-console-plugin-release-coo-ocp-4.22__upstream-amd64-aws.yaml
@@ -15,7 +15,7 @@ build_root:
   image_stream_tag:
     name: builder
     namespace: ocp
-    tag: rhel-9-golang-1.23-openshift-4.22
+    tag: rhel-9-golang-1.24-openshift-4.22
 images:
   items:
   - dockerfile_path: Dockerfile

--- a/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.12-amd64.yaml
+++ b/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.12-amd64.yaml
@@ -11,7 +11,8 @@ base_images:
     name: "4.12"
     namespace: ocp
     tag: upi-installer
-binary_build_commands: unset GOFLAGS && make manager && make targetallocator && make
+binary_build_commands: unset GOFLAGS && make CONTROLLER_TOOLS_VERSION=v0.20.1 manager
+  && make CONTROLLER_TOOLS_VERSION=v0.20.1 targetallocator && make CONTROLLER_TOOLS_VERSION=v0.20.1
   operator-opamp-bridge
 build_root:
   image_stream_tag:

--- a/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.21-amd64.yaml
+++ b/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.21-amd64.yaml
@@ -7,7 +7,8 @@ base_images:
     name: "4.19"
     namespace: origin
     tag: operator-sdk
-binary_build_commands: unset GOFLAGS && make manager && make targetallocator && make
+binary_build_commands: unset GOFLAGS && make CONTROLLER_TOOLS_VERSION=v0.20.1 manager
+  && make CONTROLLER_TOOLS_VERSION=v0.20.1 targetallocator && make CONTROLLER_TOOLS_VERSION=v0.20.1
   operator-opamp-bridge
 build_root:
   image_stream_tag:

--- a/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.22-amd64.yaml
+++ b/ci-operator/config/openshift/open-telemetry-opentelemetry-operator/openshift-open-telemetry-opentelemetry-operator-main__upstream-ocp-4.22-amd64.yaml
@@ -7,7 +7,8 @@ base_images:
     name: "4.19"
     namespace: origin
     tag: operator-sdk
-binary_build_commands: unset GOFLAGS && make manager && make targetallocator && make
+binary_build_commands: unset GOFLAGS && make CONTROLLER_TOOLS_VERSION=v0.20.1 manager
+  && make CONTROLLER_TOOLS_VERSION=v0.20.1 targetallocator && make CONTROLLER_TOOLS_VERSION=v0.20.1
   operator-opamp-bridge
 build_root:
   image_stream_tag:

--- a/ci-operator/step-registry/distributed-tracing/tests/opentelemetry/upstream/distributed-tracing-tests-opentelemetry-upstream-commands.sh
+++ b/ci-operator/step-registry/distributed-tracing/tests/opentelemetry/upstream/distributed-tracing-tests-opentelemetry-upstream-commands.sh
@@ -147,6 +147,15 @@ chainsaw test \
 tests/e2e-instrumentation \
 tests/e2e-multi-instrumentation || any_errors=true
 
+# Execute TLS profile tests
+chainsaw test \
+--quiet \
+--report-name "junit_otel_e2e_tls_profile" \
+--report-path "$ARTIFACT_DIR" \
+--report-format "XML" \
+--test-dir \
+tests/e2e-openshift-tls-profile || any_errors=true
+
 # Check if any errors occurred
 if $any_errors; then
   echo "Tests failed, check the logs for more details."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes OpenShift CI job failures for the Tracing UI and the OpenTelemetry operator by updating ci-operator metadata and the distributed-tracing test script. It touches CI configuration for two component repos: openshift/distributed-tracing-console-plugin and openshift/open-telemetry-opentelemetry-operator.

### Distributed Tracing Console Plugin (openshift/distributed-tracing-console-plugin)
- Updated the ci-operator release metadata for the distributed-tracing-console-plugin (release-coo-ocp-4.22 variant) to use the builder image tag rhel-9-golang-1.24-openshift-4.22. This moves the build root to Go 1.24 for the OCP 4.22 pipeline, ensuring the tracing UI builds in the expected runtime/toolchain.

### OpenTelemetry Operator (openshift/open-telemetry-opentelemetry-operator)
- Updated ci-operator configs for upstream OCP variants (4.12, 4.21, 4.22):
  - Replaced the previous combined make invocation with explicit build steps that unset GOFLAGS and invoke make with CONTROLLER_TOOLS_VERSION=v0.20.1 for each target (manager, targetallocator, operator-opamp-bridge). This pins controller-tools to v0.20.1 and makes the build steps explicit to avoid flaky/incorrect builds.
  - Those files also reference a newer build_root image (rhel-9-golang-1.25-openshift-4.22) for the operator jobs.
- Practical effect: CI builds for the OpenTelemetry operator will run with a pinned controller-tools version and a consistent Go builder image, reducing build failures caused by implicit flags or tooling skew.

### Distributed Tracing test script (ci-operator step-registry)
- The upstream distributed-tracing OpenTelemetry test driver script now includes an additional e2e TLS profile test run (tests/e2e-openshift-tls-profile) and collects its JUnit XML report (junit_otel_e2e_tls_profile). Test failures are aggregated via the existing any_errors handling instead of halting immediately.

### Why
- These changes stabilize CI by aligning builder images and pinning controller-tools, and by expanding the e2e test coverage (TLS profile) in the distributed-tracing test runner. They address CI failures reported by the distributed-tracing console-plugin change set.

### Review notes
- Changes are limited to ci-operator YAML and a test script; no source code or exported public APIs were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->