### PR TITLE
Whitelist mta-crane repo

### DIFF
--- a/core-services/openshift-priv/_whitelist.yaml
+++ b/core-services/openshift-priv/_whitelist.yaml
@@ -92,6 +92,7 @@ whitelist:
     - mta-java-analyzer-bundle
     - mta-kai
     - mta-kantra
+    - mta-crane
     - mta-operator
     - mta-static-report
     - mta-tackle2-addon-analyzer


### PR DESCRIPTION
Adding mta-crane repo from migtools to start onboarding mta-crane CLI with ART builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds the `mta-crane` repository to the operator whitelist in OpenShift's CI infrastructure configuration. Specifically, it updates the `migtools` operator allowlist in `core-services/openshift-priv/_whitelist.yaml` to include `mta-crane` alongside other Migration Toolkit for Applications (MTA) components already in the whitelist such as `mta-operator`, `mta-kantra`, `mta-kai`, and `mta-java-analyzer-bundle`.

The whitelist controls which component repositories are approved to use OpenShift CI infrastructure capabilities. By adding `mta-crane` to the `migtools` operator allowlist, the repository gains access to the necessary CI/infrastructure resources for its builds and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->